### PR TITLE
Add sae_set_name to local_path for dictionary downloader

### DIFF
--- a/pretrained_dictionary_downloader.sh
+++ b/pretrained_dictionary_downloader.sh
@@ -59,7 +59,7 @@ fi
 for a_value in "${a_values[@]}"; do
     for c in "${c_values[@]}"; do
         DOWNLOAD_URL="${BASE_URL}/${a_value}/${sae_set_name}/${c}"
-        LOCAL_PATH="${LOCAL_DIR}/${a_value}/${c}"
+        LOCAL_PATH="${LOCAL_DIR}/${a_value}/${sae_set_name}/${c}"
         if [ "${c}" == "checkpoints" ]; then
             # Special handling for downloading checkpoints as folders
             mkdir -p "${LOCAL_PATH}"


### PR DESCRIPTION
When I was running [bib_shift.ipynb](https://github.com/saprmarks/feature-circuits/blob/main/experiments/bib_shift.ipynb) it expected the downloaded dictionaries to be in: `/dictionaries/pythia-70m-deduped/embed/10_32768/ae.pt`

But after running the `pretrained_dictionary_downloader.sh`, they were actually in: `/dictionaries/pythia-70m-deduped/embed/ae.pt`

Adding sae_set_name to the local_path and rerunning the shell script made the bib_shift notebook run without any errors. This also appears to be the format that's expected in the dictionary_learning README.