### PR TITLE
Add  option to train Gated SAEs

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "cSpell.words": ["autoencoded"]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,3 @@
 {
-  "cSpell.words": ["autoencoded"]
+  "cSpell.words": ["autoencoded", "binarisation"]
 }

--- a/__init__.py
+++ b/__init__.py
@@ -1,2 +1,2 @@
-from .dictionary import AutoEncoder
 from .buffer import ActivationBuffer
+from .dictionary import AutoEncoder, GatedAutoEncoder

--- a/buffer.py
+++ b/buffer.py
@@ -3,6 +3,7 @@ from nnsight import LanguageModel
 
 from .config import DEBUG
 
+tracer_kwargs: dict
 if DEBUG:
     tracer_kwargs = {"scan": True, "validate": True}
 else:
@@ -105,7 +106,7 @@ class ActivationBuffer:
             with t.no_grad():
                 with self.model.trace(
                     self.text_batch(),
-                    kwargs=tracer_kwargs,
+                    **tracer_kwargs,
                     invoker_args={"truncation": True, "max_length": self.ctx_len},
                 ):
                     if self.io == "in":

--- a/buffer.py
+++ b/buffer.py
@@ -105,8 +105,8 @@ class ActivationBuffer:
             with t.no_grad():
                 with self.model.trace(
                     self.text_batch(),
-                    **tracer_kwargs,
-                    invoker_args={"truncation": True, "max_length": self.ctx_len}
+                    kwargs=tracer_kwargs,
+                    invoker_args={"truncation": True, "max_length": self.ctx_len},
                 ):
                     if self.io == "in":
                         hidden_states = self.submodule.input[0].save()

--- a/buffer.py
+++ b/buffer.py
@@ -1,11 +1,12 @@
 import torch as t
 from nnsight import LanguageModel
+
 from .config import DEBUG
 
 if DEBUG:
-    tracer_kwargs = {'scan' : True, 'validate' : True}
+    tracer_kwargs = {"scan": True, "validate": True}
 else:
-    tracer_kwargs = {'scan' : False, 'validate' : False}
+    tracer_kwargs = {"scan": False, "validate": False}
 
 
 class ActivationBuffer:
@@ -13,30 +14,34 @@ class ActivationBuffer:
     Implements a buffer of activations. The buffer stores activations from a model,
     yields them in batches, and refreshes them when the buffer is less than half full.
     """
-    def __init__(self, 
-                 data, # generator which yields text data
-                 model : LanguageModel, # LanguageModel from which to extract activations
-                 submodule, # submodule of the model from which to extract activations
-                 d_submodule=None, # submodule dimension; if None, try to detect automatically
-                 io='out', # can be 'in' or 'out'; whether to extract input or output activations
-                 n_ctxs=3e4, # approximate number of contexts to store in the buffer
-                 ctx_len=128, # length of each context
-                 refresh_batch_size=512, # size of batches in which to process the data when adding to buffer
-                 out_batch_size=8192, # size of batches in which to yield activations
-                 device='cpu' # device on which to store the activations
-                 ):
-        
-        if io not in ['in', 'out']:
+
+    def __init__(
+        self,
+        data,  # generator which yields text data
+        model: LanguageModel,  # LanguageModel from which to extract activations
+        submodule,  # submodule of the model from which to extract activations
+        d_submodule=None,  # submodule dimension; if None, try to detect automatically
+        io="out",  # can be 'in' or 'out'; whether to extract input or output activations
+        n_ctxs=3e4,  # approximate number of contexts to store in the buffer
+        ctx_len=128,  # length of each context
+        refresh_batch_size=512,  # size of batches in which to process the data when adding to buffer
+        out_batch_size=8192,  # size of batches in which to yield activations
+        device="cpu",  # device on which to store the activations
+    ):
+
+        if io not in ["in", "out"]:
             raise ValueError("io must be either 'in' or 'out'")
 
         if d_submodule is None:
             try:
-                if io == 'in':
+                if io == "in":
                     d_submodule = submodule.in_features
                 else:
                     d_submodule = submodule.out_features
             except:
-                raise ValueError("d_submodule cannot be inferred and must be specified directly")
+                raise ValueError(
+                    "d_submodule cannot be inferred and must be specified directly"
+                )
         self.activations = t.empty(0, d_submodule, device=device)
 
         self.read = t.zeros(0).bool()
@@ -51,7 +56,7 @@ class ActivationBuffer:
         self.refresh_batch_size = refresh_batch_size
         self.out_batch_size = out_batch_size
         self.device = device
-    
+
     def __iter__(self):
         return self
 
@@ -66,10 +71,12 @@ class ActivationBuffer:
 
             # return a batch
             unreads = (~self.read).nonzero().squeeze()
-            idxs = unreads[t.randperm(len(unreads), device=unreads.device)[:self.out_batch_size]]
+            idxs = unreads[
+                t.randperm(len(unreads), device=unreads.device)[: self.out_batch_size]
+            ]
             self.read[idxs] = True
             return self.activations[idxs]
-    
+
     def text_batch(self, batch_size=None):
         """
         Return a list of text
@@ -77,38 +84,36 @@ class ActivationBuffer:
         if batch_size is None:
             batch_size = self.refresh_batch_size
         try:
-            return [
-                next(self.data) for _ in range(batch_size)
-            ]
+            return [next(self.data) for _ in range(batch_size)]
         except StopIteration:
             raise StopIteration("End of data stream reached")
-    
+
     def tokenized_batch(self, batch_size=None):
         """
         Return a batch of tokenized inputs.
         """
         texts = self.text_batch(batch_size=batch_size)
         return self.model.tokenizer(
-            texts,
-            return_tensors='pt',
-            max_length=self.ctx_len,
-            padding=True,
-            truncation=True
+            texts, return_tensors="pt", max_length=self.ctx_len, padding=True, truncation=True
         )
 
     def refresh(self):
         self.activations = self.activations[~self.read]
 
         while len(self.activations) < self.n_ctxs * self.ctx_len:
-            
+
             with t.no_grad():
-                with self.model.trace(self.text_batch(), **tracer_kwargs, invoker_args={'truncation': True, 'max_length': self.ctx_len}):
-                    if self.io == 'in':
+                with self.model.trace(
+                    self.text_batch(),
+                    **tracer_kwargs,
+                    invoker_args={"truncation": True, "max_length": self.ctx_len}
+                ):
+                    if self.io == "in":
                         hidden_states = self.submodule.input[0].save()
                     else:
                         hidden_states = self.submodule.output.save()
                     input = self.model.input.save()
-            attn_mask = input.value[1]['attention_mask']
+            attn_mask = input.value[1]["attention_mask"]
             hidden_states = hidden_states.value
             if isinstance(hidden_states, tuple):
                 hidden_states = hidden_states[0]

--- a/dictionary.py
+++ b/dictionary.py
@@ -102,6 +102,10 @@ class AutoEncoder(Dictionary, nn.Module):
 
 
 class GatedAutoEncoder(Dictionary, nn.Module):
+    """An autoencoder with a gating mechanism as given in Improving Dictionary Learning with
+    Gated Sparse Autoencoders (Rajamanoharan et al 2024)
+    """
+
     def __init__(self, activation_dim: int, dict_size: int):
         super().__init__()
         self.activation_dim = activation_dim
@@ -140,9 +144,13 @@ class GatedAutoEncoder(Dictionary, nn.Module):
         features = self.decoder(features) + self.bias
         return features
 
-    def forward(
-        self, x: t.Tensor, output_features: bool = False, ghost_mask: Optional[t.Tensor] = None
-    ):
+    def forward(self, x: t.Tensor, output_features: bool = False):
+        """
+        Forward pass of the Gated Sparse Autoencoder.
+        x : activations to be autoencoded
+        output_features : if True, return the encoded features, active_features
+            and feature_magnitude tensors as well as the decoded x
+        """
         features, active_features, feature_magnitudes = self.encode(x)
         x_hat = self.decode(features)
         if output_features:

--- a/dictionary.py
+++ b/dictionary.py
@@ -88,16 +88,19 @@ class AutoEncoder(Dictionary, nn.Module):
                 return x_hat, x_ghost
 
     @classmethod
-    def from_pretrained(cls, path, device=None):
+    def from_pretrained(cls, path: str, device: Optional[t.device] = None):
         """
         Load a pretrained autoencoder from a file.
         """
         state_dict = t.load(path)
         dict_size, activation_dim = state_dict["encoder.weight"].shape
+
         autoencoder = AutoEncoder(activation_dim, dict_size)
         autoencoder.load_state_dict(state_dict)
+
         if device is not None:
             autoencoder.to(device)
+
         return autoencoder
 
 
@@ -166,6 +169,22 @@ class GatedAutoEncoder(Dictionary, nn.Module):
             )
         else:
             return x_hat
+
+    @classmethod
+    def from_pretrained(cls, path: str, device: Optional[t.device] = None):
+        """
+        Load a pretrained autoencoder from a file.
+        """
+        state_dict = t.load(path)
+        dict_size, activation_dim = state_dict["active_features_encoder.weight"].shape
+
+        autoencoder = GatedAutoEncoder(activation_dim, dict_size)
+        autoencoder.load_state_dict(state_dict)
+
+        if device is not None:
+            autoencoder.to(device)
+
+        return autoencoder
 
 
 class IdentityDict(Dictionary, nn.Module):

--- a/dictionary.py
+++ b/dictionary.py
@@ -148,7 +148,12 @@ class GatedAutoEncoder(Dictionary, nn.Module):
         features = self.decoder(features) + self.bias
         return features
 
-    def forward(self, x: t.Tensor, output_features: bool = False):
+    def forward(
+        self,
+        x: t.Tensor,
+        output_features: bool = False,
+        output_intermediate_activations: bool = False,
+    ):
         """
         Forward pass of the Gated Sparse Autoencoder.
         x : activations to be autoencoded
@@ -159,7 +164,7 @@ class GatedAutoEncoder(Dictionary, nn.Module):
             self.encode(x)
         )
         x_hat = self.decode(features)
-        if output_features:
+        if output_intermediate_activations:
             return (
                 x_hat,
                 features,
@@ -167,6 +172,8 @@ class GatedAutoEncoder(Dictionary, nn.Module):
                 active_features,
                 feature_magnitudes,
             )
+        elif output_features:
+            return x_hat, features
         else:
             return x_hat
 

--- a/dictionary.py
+++ b/dictionary.py
@@ -3,35 +3,41 @@ Defines the dictionary classes
 """
 
 from abc import ABC, abstractmethod
+from typing import Optional
+
 import torch as t
 import torch.nn as nn
+
 
 class Dictionary(ABC):
     """
     A dictionary consists of a collection of vectors, an encoder, and a decoder.
     """
-    dict_size : int # number of features in the dictionary
-    activation_dim : int # dimension of the activation vectors
+
+    dict_size: int  # number of features in the dictionary
+    activation_dim: int  # dimension of the activation vectors
 
     @abstractmethod
-    def encode(self, x):
+    def encode(self, x: t.Tensor) -> t.Tensor:
         """
         Encode a vector x in the activation space.
         """
         pass
-    
+
     @abstractmethod
-    def decode(self, f):
+    def decode(self, f: t.Tensor) -> t.Tensor:
         """
         Decode a dictionary vector f (i.e. a linear combination of dictionary elements)
         """
         pass
 
+
 class AutoEncoder(Dictionary, nn.Module):
     """
     A one-layer autoencoder.
     """
-    def __init__(self, activation_dim, dict_size):
+
+    def __init__(self, activation_dim: int, dict_size: int):
         super().__init__()
         self.activation_dim = activation_dim
         self.dict_size = dict_size
@@ -44,67 +50,74 @@ class AutoEncoder(Dictionary, nn.Module):
         dec_weight = dec_weight / dec_weight.norm(dim=0, keepdim=True)
         self.decoder.weight = nn.Parameter(dec_weight)
 
-    def encode(self, x):
+    def encode(self, x: t.Tensor) -> t.Tensor:
         return nn.ReLU()(self.encoder(x - self.bias))
-    
-    def decode(self, f):
+
+    def decode(self, f: t.Tensor) -> t.Tensor:
         return self.decoder(f) + self.bias
-    
-    def forward(self, x, output_features=False, ghost_mask=None):
+
+    def forward(
+        self, x: t.Tensor, output_features: bool = False, ghost_mask: Optional[t.Tensor] = None
+    ):
         """
         Forward pass of an autoencoder.
         x : activations to be autoencoded
         output_features : if True, return the encoded features as well as the decoded x
         ghost_mask : if not None, run this autoencoder in "ghost mode" where features are masked
         """
-        if ghost_mask is None: # normal mode
+        if ghost_mask is None:  # normal mode
             f = self.encode(x)
             x_hat = self.decode(f)
             if output_features:
                 return x_hat, f
             else:
                 return x_hat
-        
-        else: # ghost mode
+
+        else:  # ghost mode
             f_pre = self.encoder(x - self.bias)
             f_ghost = t.exp(f_pre) * ghost_mask.to(f_pre)
             f = nn.ReLU()(f_pre)
 
-            x_ghost = self.decoder(f_ghost) # note that this only applies the decoder weight matrix, no bias
+            x_ghost = self.decoder(
+                f_ghost
+            )  # note that this only applies the decoder weight matrix, no bias
             x_hat = self.decode(f)
             if output_features:
                 return x_hat, x_ghost, f
             else:
                 return x_hat, x_ghost
-            
-    def from_pretrained(path, device=None):
+
+    @classmethod
+    def from_pretrained(cls, path, device=None):
         """
         Load a pretrained autoencoder from a file.
         """
         state_dict = t.load(path)
-        dict_size, activation_dim = state_dict['encoder.weight'].shape
+        dict_size, activation_dim = state_dict["encoder.weight"].shape
         autoencoder = AutoEncoder(activation_dim, dict_size)
         autoencoder.load_state_dict(state_dict)
         if device is not None:
             autoencoder.to(device)
         return autoencoder
-            
+
+
 class IdentityDict(Dictionary, nn.Module):
     """
     An identity dictionary, i.e. the identity function.
     """
-    def __init__(self, activation_dim=None):
-        super().__init__()
-        self.activation_dim = activation_dim
-        self.dict_size = activation_dim
 
-    def encode(self, x):
+    def __init__(self, activation_dim: Optional[int] = None):
+        super().__init__()
+
+    def encode(self, x: t.Tensor) -> t.Tensor:
         return x
-    
-    def decode(self, f):
+
+    def decode(self, f: t.Tensor) -> t.Tensor:
         return f
-    
-    def forward(self, x, output_features=False, ghost_mask=None):
+
+    def forward(
+        self, x: t.Tensor, output_features: bool = False, ghost_mask: Optional[t.Tensor] = None
+    ):
         if output_features:
             return x, x
         else:

--- a/example.py
+++ b/example.py
@@ -1,0 +1,46 @@
+from nnsight import LanguageModel
+
+from .buffer import ActivationBuffer
+from .training import trainSAE
+
+EXPANSION_FACTOR = 8
+DEVICE = "mps"
+
+model = LanguageModel(
+    "EleutherAI/pythia-70m-deduped", device_map=DEVICE  # this can be any Huggingface model
+)
+
+submodule = model.gpt_neox.layers[1].mlp  # layer 1 MLP
+activation_dim = 512  # dimension of the activations in pythia-70m
+dictionary_size = EXPANSION_FACTOR * activation_dim
+
+# data much be an iterator that outputs strings
+data = iter(
+    [
+        "This is some example data",
+        "In real life, for training a dictionary",
+        "you would need much more data than this",
+    ]
+)
+
+buffer = ActivationBuffer(
+    data,
+    model,
+    submodule,
+    d_submodule=activation_dim,  # output dimension of the model component
+    n_ctxs=3e4,  # you can set this higher or lower dependong on your available memory
+    device=DEVICE,  # doesn't have to be the same device that you train your autoencoder on
+)  # buffer will return batches of tensors of dimension = submodule's output dimension
+
+# train the sparse autoencoder (SAE)
+ae = trainSAE(
+    buffer,
+    activation_dim,
+    dictionary_size,
+    lr=3e-4,
+    sparsity_penalty=1e-3,
+    device=DEVICE,
+    use_gated_sae=True,
+)
+
+print("Done!")

--- a/example.py
+++ b/example.py
@@ -32,15 +32,26 @@ buffer = ActivationBuffer(
     device=DEVICE,  # doesn't have to be the same device that you train your autoencoder on
 )  # buffer will return batches of tensors of dimension = submodule's output dimension
 
-# train the sparse autoencoder (SAE)
-ae = trainSAE(
-    buffer,
-    activation_dim,
-    dictionary_size,
-    lr=3e-4,
-    sparsity_penalty=1e-3,
-    device=DEVICE,
-    use_gated_sae=True,
-)
+# train the sparse autoencoders (SAEs)
+if __name__ == "__main__":
+    trained_gated_ae = trainSAE(
+        buffer,
+        activation_dim,
+        dictionary_size,
+        lr=3e-4,
+        sparsity_penalty=1e-3,
+        device=DEVICE,
+        use_gated_sae=True,
+    )
 
-print("Done!")
+    trained_regular_ae = trainSAE(
+        buffer,
+        activation_dim,
+        dictionary_size,
+        lr=3e-4,
+        sparsity_penalty=1e-3,
+        device=DEVICE,
+        use_gated_sae=False,
+    )
+
+    print("Done!")

--- a/training.py
+++ b/training.py
@@ -219,7 +219,7 @@ def trainSAE(
     lr,
     sparsity_penalty,
     entropy=False,
-    total_train_steps=None,  # if None, train until activations are exhausted
+    steps=None,  # if None, train until activations are exhausted
     warmup_steps=1000,  # linearly increase the learning rate for this many steps
     resample_steps=None,  # how often to resample dead neurons
     ghost_threshold=None,  # how many steps a neuron has to be dead for it to turn into a ghost
@@ -257,8 +257,8 @@ def trainSAE(
 
     scheduler = t.optim.lr_scheduler.LambdaLR(optimizer, lr_lambda=warmup_fn)
 
-    for step, acts in enumerate(tqdm(activations, total=total_train_steps)):
-        if total_train_steps is not None and step >= total_train_steps:
+    for step, acts in enumerate(tqdm(activations, total=steps)):
+        if steps is not None and step >= steps:
             break
 
         if isinstance(acts, t.Tensor):  # typical case

--- a/training.py
+++ b/training.py
@@ -152,7 +152,10 @@ def gated_sae_loss(
     # Apply a reconstruction loss on the gating encoder to encourage it to
     # reconstruct well. We apply a stop gradient for the decoding.
     with t.no_grad():
-        gating_only_reconstruction = gated_autoencoder.decode(relued_gates)
+        decoder_weights = gated_autoencoder.decoder.weight
+        decoder_bias = gated_autoencoder.decoder.bias
+
+    gating_only_reconstruction = relued_gates @ decoder_weights + decoder_bias
     gating_reconstruction_loss = mse_criterion(activations, gating_only_reconstruction)
 
     if output_all_losses:

--- a/training.py
+++ b/training.py
@@ -138,7 +138,7 @@ def gated_sae_loss(
         active_features_pre_binarisation,
         _active_features,
         _feature_magnitudes,
-    ) = gated_autoencoder(activations, output_features=True)
+    ) = gated_autoencoder(activations, output_intermediate_activations=True)
 
     # We’ll use the reconstruction from the baseline forward pass to train
     # the magnitudes encoder and decoder.

--- a/training.py
+++ b/training.py
@@ -71,6 +71,7 @@ def sae_loss(
         in_acts = out_acts = activations
 
     ghost_grads = False
+    ghost_loss = None
     if ghost_threshold is not None:
         if num_samples_since_activated is None:
             raise ValueError("num_samples_since_activated must be provided for ghost grads")


### PR DESCRIPTION
In a recent DeepMind paper, [Improving Dictionary Learning with Gated Sparse Autoencoders](https://arxiv.org/abs/2404.16014) (Rajamanoharan et al 2024), the authors suggest a Pareto improvement to the regular dictionary learning procedure. 

This PR adds that recipe to the dictionary_learning repo. 

There are also some other small changes in applying the black formatter, applying isort to sort imports and adding some type hints to the relevant areas of the codebase. 

I ran the example.py script to check that the GatedSAE training loop runs as expected. 

Excited to train GatedSAEs!

Let me know if you have any questions about this, the formatting changes make it seem like there's a lot of change but really most of the changes are localised to dictionary.py in the GatedAutoEncoder class and in editing the training script/loss function to work with this. 

(Also I'm using regular black formatting settings because there isn't a formatting specified in the repo but if you have a formatter that you prefer please let me know or feel free to just run your own auto-formatter on top of this change before you merge!)