### PR TITLE
small bug fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,8 @@ Here's an example for training a dictionary; in it we load a language model as a
 ```python
 from nnsight import LanguageModel
 from dictionary_learning import ActivationBuffer
+from dictionary_learning.dictionary import AutoEncoder
+from dictionary_learning.trainers.standard import StandardTrainer
 from dictionary_learning.training import trainSAE
 
 sae_device = "cuda:0"

--- a/README.md
+++ b/README.md
@@ -75,37 +75,55 @@ from nnsight import LanguageModel
 from dictionary_learning import ActivationBuffer
 from dictionary_learning.training import trainSAE
 
+sae_device = "cuda:0"
+activation_device = "cuda:0" # these can be the same but don't have to be
+lm_name = "EleutherAI/pythia-70m-deduped" # this can be any Huggingface model
+
 model = LanguageModel(
-    'EleutherAI/pythia-70m-deduped', # this can be any Huggingface model
-    device_map = 'cuda:0'
+    lm_name,
+    device_map=activation_device,
 )
 submodule = model.gpt_neox.layers[1].mlp # layer 1 MLP
 activation_dim = 512 # output dimension of the MLP
 dictionary_size = 16 * activation_dim
 
-# data much be an iterator that outputs strings
-data = iter([
-    'This is some example data',
-    'In real life, for training a dictionary',
-    'you would need much more data than this'
-])
+# data must be an iterator that outputs strings
+data = iter(
+    [
+        "This is some example data",
+        "In real life, for training a dictionary",
+        "you would need much more data than this",
+    ]
+    * 10_000 # synthetically increase amount of toy data since training only runs 1 epoch
+)
 buffer = ActivationBuffer(
-    data,
-    model,
-    submodule,
+    data=data,
+    model=model,
+    submodule=submodule,
     d_submodule=activation_dim, # output dimension of the model component
-    n_ctxs=3e4, # you can set this higher or lower dependong on your available memory
-    device='cuda:0' # doesn't have to be the same device that you train your autoencoder on
-) # buffer will return batches of tensors of dimension = submodule's output dimension
+    n_ctxs=3e2,  # you can set this higher or lower dependong on your available memory
+    out_batch_size=256,
+    device=activation_device,
+)  # buffer will return batches of tensors of dimension = submodule's output dimension
+
+trainer_cfg = {
+    "trainer": StandardTrainer,
+    "dict_class": AutoEncoder,
+    "activation_dim": activation_dim,
+    "dict_size": dictionary_size,
+    "lr": 1e-3,
+    "seed": 0,
+    "wandb_name": "sae_test",
+    "layer": "mlp_1",  # name of the layer in the model, used for logging
+    "lm_name": lm_name,  # name of the model, used for logging
+    "device": sae_device,
+}
 
 # train the sparse autoencoder (SAE)
 ae = trainSAE(
-    buffer,
-    activation_dim,
-    dictionary_size,
-    lr=3e-4,
-    sparsity_penalty=1e-3,
-    device='cuda:0'
+    data=buffer,  # you could also use another (i.e. pytorch dataloader) here instead of buffer
+    trainer_configs=[trainer_cfg],
+    steps=25,  # you'll want to increase this number in practi
 )
 ```
 Some technical notes our training infrastructure and supported features:

--- a/training.py
+++ b/training.py
@@ -18,7 +18,7 @@ def trainSAE(
                 'trainer' : StandardTrainer,
                 'dict_class' : AutoEncoder,
                 'activation_dim' : 512,
-                'dictionary_size' : 64*512,
+                'dict_size' : 64*512,
                 'lr' : 1e-3,
                 'l1_penalty' : 1e-1,
                 'warmup_steps' : 1000,


### PR DESCRIPTION
two small fixes to get an SAE training example running
* the README example for training an SAE was out of date so updated it to use the trainer config
* one of the default args in trainSAE was set as "dictionary_size" when it actually called via "dict_size"