### PR TITLE
Use separate wandb runs for each SAE being trained

### DIFF
--- a/training.py
+++ b/training.py
@@ -34,9 +34,9 @@ def log_stats(
     trainers,
     step: int,
     act: t.Tensor,
-    log_queues: list,
     activations_split_by_head: bool,
     transcoder: bool,
+    log_queues: list=[],
 ):
     with t.no_grad():
         # quick hack to make sure all trainers get the same x
@@ -69,7 +69,8 @@ def log_stats(
             for name, value in trainer_log.items():
                 log[f"{name}"] = value
 
-            log_queues[i].put(log)
+            if log_queues:
+                log_queues[i].put(log)
 
 
 def trainSAE(
@@ -135,7 +136,7 @@ def trainSAE(
         # logging
         if log_steps is not None and step % log_steps == 0:
             log_stats(
-                trainers, step, act, log_queues, activations_split_by_head, transcoder
+                trainers, step, act, activations_split_by_head, transcoder, log_queues=log_queues
             )
 
         # saving

--- a/training.py
+++ b/training.py
@@ -2,35 +2,52 @@
 Training dictionaries
 """
 
-import torch as t
-from .dictionary import AutoEncoder
-import os
-from tqdm import tqdm
-from .trainers.standard import StandardTrainer
-import wandb
 import json
-# from .evaluation import evaluate
+import multiprocessing as mp
+import os
+from queue import Empty
+
+import torch as t
+from tqdm import tqdm
+
+import wandb
+
+from .dictionary import AutoEncoder
+from .evaluation import evaluate
+from .trainers.standard import StandardTrainer
+
+
+def new_wandb_process(config, log_queue, entity, project):
+    wandb.init(entity=entity, project=project, config=config, name=config["wandb_name"])
+    while True:
+        try:
+            log = log_queue.get(timeout=1)
+            if log == "DONE":
+                break
+            wandb.log(log)
+        except Empty:
+            continue
+    wandb.finish()
+
 
 def log_stats(
     trainers,
     step: int,
     act: t.Tensor,
-    use_wandb: bool,
+    log_queues: list,
     activations_split_by_head: bool,
     transcoder: bool,
 ):
-    log = {}
     with t.no_grad():
         # quick hack to make sure all trainers get the same x
-        # TODO make this less hacky
         z = act.clone()
         for i, trainer in enumerate(trainers):
+            log = {}
             act = z.clone()
             if activations_split_by_head:  # x.shape: [batch, pos, n_heads, d_head]
                 act = act[..., i, :]
-            trainer_name = f'{trainer.config["wandb_name"]}-{i}'
             if not transcoder:
-                act, act_hat, f, losslog = trainer.loss(act, step=step, logging=True)  # act is x
+                act, act_hat, f, losslog = trainer.loss(act, step=step, logging=True)
 
                 # L0
                 l0 = (f != 0).float().sum(dim=-1).mean().item()
@@ -38,114 +55,89 @@ def log_stats(
                 total_variance = t.var(act, dim=0).sum()
                 residual_variance = t.var(act - act_hat, dim=0).sum()
                 frac_variance_explained = 1 - residual_variance / total_variance
-                log[f"{trainer_name}/frac_variance_explained"] = frac_variance_explained.item()
+                log[f"frac_variance_explained"] = frac_variance_explained.item()
             else:  # transcoder
-                x, x_hat, f, losslog = trainer.loss(act, step=step, logging=True)  # act is x, y
+                x, x_hat, f, losslog = trainer.loss(act, step=step, logging=True)
 
                 # L0
                 l0 = (f != 0).float().sum(dim=-1).mean().item()
 
-                # fraction of variance explained
-                # TODO: adapt for transcoder
-                # total_variance = t.var(x, dim=0).sum()
-                # residual_variance = t.var(x - x_hat, dim=0).sum()
-                # frac_variance_explained = (1 - residual_variance / total_variance)
-                # log[f'{trainer_name}/frac_variance_explained'] = frac_variance_explained.item()
-
             # log parameters from training
-            log.update({f"{trainer_name}/{k}": v for k, v in losslog.items()})
-            log[f"{trainer_name}/l0"] = l0
+            log.update({f"{k}": v for k, v in losslog.items()})
+            log[f"l0"] = l0
             trainer_log = trainer.get_logging_parameters()
             for name, value in trainer_log.items():
-                log[f"{trainer_name}/{name}"] = value
+                log[f"{name}"] = value
 
-            # TODO get this to work
-            # metrics = evaluate(
-            #     trainer.ae,
-            #     data,
-            #     device=trainer.device
-            # )
-            # log.update(
-            #     {f'trainer{i}/{k}' : v for k, v in metrics.items()}
-            # )
-    if use_wandb:
-        wandb.log(log, step=step)
+            log_queues[i].put(log)
+
 
 def trainSAE(
-        data, 
-        trainer_configs = [
-            {
-                'trainer' : StandardTrainer,
-                'dict_class' : AutoEncoder,
-                'activation_dim' : 512,
-                'dict_size' : 64*512,
-                'lr' : 1e-3,
-                'l1_penalty' : 1e-1,
-                'warmup_steps' : 1000,
-                'resample_steps' : None,
-                'seed' : None,
-                'wandb_name' : 'StandardTrainer',
-            }
-        ],
-        use_wandb = False,
-        wandb_entity = "",
-        wandb_project = "",
-        steps=None,
-        save_steps=None,
-        save_dir=None, # use {run} to refer to wandb run
-        log_steps=None,
-        activations_split_by_head=False, # set to true if data is shape [batch, pos, num_head, head_dim/resid_dim]
-        transcoder=False,
+    data,
+    trainer_configs,
+    use_wandb=False,
+    wandb_entity="",
+    wandb_project="",
+    steps=None,
+    save_steps=None,
+    save_dir=None,
+    log_steps=None,
+    activations_split_by_head=False,
+    transcoder=False,
+    run_cfg={},
 ):
     """
     Train SAEs using the given trainers
     """
-
     trainers = []
     for config in trainer_configs:
-        trainer = config['trainer']
-        del config['trainer']
-        trainers.append(
-            trainer(
-                **config
-            )
-        )
+        trainer_class = config["trainer"]
+        del config["trainer"]
+        trainers.append(trainer_class(**config))
 
+    wandb_processes = []
+    log_queues = []
 
-    if log_steps is not None:
-        if use_wandb:
-            wandb.init(
-                entity=wandb_entity,
-                project=wandb_project,
-                config={f'{trainer.config["wandb_name"]}-{i}' : trainer.config for i, trainer in enumerate(trainers)}
+    if use_wandb:
+        for i, trainer in enumerate(trainers):
+            log_queue = mp.Queue()
+            log_queues.append(log_queue)
+            wandb_config = trainer.config | run_cfg
+            wandb_process = mp.Process(
+                target=new_wandb_process,
+                args=(wandb_config, log_queue, wandb_entity, wandb_project),
             )
-            # process save_dir in light of run name
-            if save_dir is not None:
-                save_dir = save_dir.format(run=wandb.run.name)
+            wandb_process.start()
+            wandb_processes.append(wandb_process)
 
     # make save dirs, export config
     if save_dir is not None:
-        save_dirs = [os.path.join(save_dir, f"trainer_{i}") for i in range(len(trainer_configs))]
+        save_dirs = [
+            os.path.join(save_dir, f"trainer_{i}") for i in range(len(trainer_configs))
+        ]
         for trainer, dir in zip(trainers, save_dirs):
             os.makedirs(dir, exist_ok=True)
             # save config
-            config = {'trainer' : trainer.config}
+            config = {"trainer": trainer.config}
             try:
-                config['buffer'] = data.config
-            except: pass
-            with open(os.path.join(dir, "config.json"), 'w') as f:
+                config["buffer"] = data.config
+            except:
+                pass
+            with open(os.path.join(dir, "config.json"), "w") as f:
                 json.dump(config, f, indent=4)
     else:
         save_dirs = [None for _ in trainer_configs]
-    
+
     for step, act in enumerate(tqdm(data, total=steps)):
         if steps is not None and step >= steps:
             break
 
         # logging
         if log_steps is not None and step % log_steps == 0:
-            log_stats(trainers, step, act, use_wandb, activations_split_by_head, transcoder)
-            
+            log_stats(
+                trainers, step, act, log_queues, activations_split_by_head, transcoder
+            )
+
         # saving
         if save_steps is not None and step % save_steps == 0:
             for dir, trainer in zip(save_dirs, trainers):
@@ -153,19 +145,22 @@ def trainSAE(
                     if not os.path.exists(os.path.join(dir, "checkpoints")):
                         os.mkdir(os.path.join(dir, "checkpoints"))
                     t.save(
-                        trainer.ae.state_dict(), 
-                        os.path.join(dir, "checkpoints", f"ae_{step}.pt")
-                        )
-                    
+                        trainer.ae.state_dict(),
+                        os.path.join(dir, "checkpoints", f"ae_{step}.pt"),
+                    )
+
         # training
         for trainer in trainers:
             trainer.update(step, act)
-    
+
     # save final SAEs
     for save_dir, trainer in zip(save_dirs, trainers):
         if save_dir is not None:
             t.save(trainer.ae.state_dict(), os.path.join(save_dir, "ae.pt"))
 
-    # End the wandb run
-    if log_steps is not None and use_wandb:
-        wandb.finish()
+    # Signal wandb processes to finish
+    if use_wandb:
+        for queue in log_queues:
+            queue.put("DONE")
+        for process in wandb_processes:
+            process.join()


### PR DESCRIPTION
Proposed improvement to wandb logging. Rather than log different metrics for each model in a run, which makes comparison and grouping across runs hard, this uses a separate run for every SAE being trained.

Each wandb run goes into its own subprocesses, and the ticks are placed onto queues for those processes to upload. I didn't see any performance hit in limited testing.