### PR TITLE
Fix BatchTopKSAE training

### DIFF
--- a/dictionary.py
+++ b/dictionary.py
@@ -2,7 +2,7 @@
 Defines the dictionary classes
 """
 
-from abc import ABC, abstractclassmethod, abstractmethod
+from abc import ABC, abstractmethod
 import torch as t
 import torch.nn as nn
 import torch.nn.init as init


### PR DESCRIPTION
The current Trainer implementation for BatchTopK is broken because it references undefined `self.W_dec`. In addition, the class couldn't be instantiated due to missing `from_pretrained` method.

1. Fixed broken auxiliary loss calculation.
2. Implemented missing abstract method to prevent instantiation issues.
3. Moved 'k' to a registered buffer for easier state dict saving/loading.
4. Added 'from_pretrained' method for loading pretrained models.