### PR TITLE
Lr scheduling

### DIFF
--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -94,7 +94,7 @@ def test_sae_training():
     learning_rate = 3e-4
 
     # topk sae training parameters
-    decay_start = 24000
+    decay_start = None
     auxk_alpha = 1 / 32
 
     submodule = model.gpt_neox.layers[LAYER]
@@ -128,6 +128,7 @@ def test_sae_training():
                 "dict_size": expansion_factor * activation_dim,
                 "k": k,
                 "auxk_alpha": auxk_alpha,  # see Appendix A.2
+                "warmup_steps": 0,
                 "decay_start": decay_start,  # when does the lr decay start
                 "steps": steps,  # when when does training end
                 "seed": RANDOM_SEED,
@@ -150,6 +151,8 @@ def test_sae_training():
                 "l1_penalty": sparsity_penalty,
                 "warmup_steps": warmup_steps,
                 "sparsity_warmup_steps": None,
+                "decay_start": decay_start,
+                "steps": steps,
                 "resample_steps": resample_steps,
                 "seed": RANDOM_SEED,
                 "wandb_name": f"StandardTrainer-{MODEL_NAME}-{submodule_name}",

--- a/training.py
+++ b/training.py
@@ -105,10 +105,10 @@ def get_norm_factor(data, steps: int) -> float:
 def trainSAE(
     data,
     trainer_configs: list[dict],
+    steps: int,
     use_wandb:bool=False,
     wandb_entity:str="",
     wandb_project:str="",
-    steps:Optional[int]=None,
     save_steps:Optional[list[int]]=None,
     save_dir:Optional[str]=None,
     log_steps:Optional[int]=None,
@@ -179,7 +179,7 @@ def trainSAE(
         if normalize_activations:
             act /= norm_factor
 
-        if steps is not None and step >= steps:
+        if step >= steps:
             break
 
         # logging


### PR DESCRIPTION
This PR standardizes the use of schedulers across all trainers in the repo. Previously, different trainers used arbitrary combinations of the following schedulers:
	•	Sparsity Penalty Warm-up
	•	Learning Rate Warm-up
	•	Learning Rate Decay

Some trainers had only learning rate decay, while others combined learning rate warm-up with sparsity penalty warm-up. Now, all trainers use the appropriate schedulers consistently, with matching arguments and configurations.