### PR TITLE
Add Matroyshka, Fix Jump ReLU training, modify initialization

### DIFF
--- a/buffer.py
+++ b/buffer.py
@@ -26,7 +26,8 @@ class ActivationBuffer:
                  ctx_len=128, # length of each context
                  refresh_batch_size=512, # size of batches in which to process the data when adding to buffer
                  out_batch_size=8192, # size of batches in which to yield activations
-                 device='cpu' # device on which to store the activations
+                 device='cpu', # device on which to store the activations
+                 remove_bos: bool = False,
                  ):
         
         if io not in ['in', 'out']:
@@ -54,6 +55,7 @@ class ActivationBuffer:
         self.refresh_batch_size = refresh_batch_size
         self.out_batch_size = out_batch_size
         self.device = device
+        self.remove_bos = remove_bos
     
     def __iter__(self):
         return self
@@ -131,6 +133,9 @@ class ActivationBuffer:
             hidden_states = hidden_states.value
             if isinstance(hidden_states, tuple):
                 hidden_states = hidden_states[0]
+            if self.remove_bos:
+                hidden_states = hidden_states[:, 1:, :]
+                attn_mask = attn_mask[:, 1:]
             hidden_states = hidden_states[attn_mask != 0]
 
             remaining_space = self.activation_buffer_size - current_idx

--- a/dictionary.py
+++ b/dictionary.py
@@ -7,12 +7,14 @@ import torch as t
 import torch.nn as nn
 import torch.nn.init as init
 
+
 class Dictionary(ABC, nn.Module):
     """
     A dictionary consists of a collection of vectors, an encoder, and a decoder.
     """
-    dict_size : int # number of features in the dictionary
-    activation_dim : int # dimension of the activation vectors
+
+    dict_size: int  # number of features in the dictionary
+    activation_dim: int  # dimension of the activation vectors
 
     @abstractmethod
     def encode(self, x):
@@ -20,7 +22,7 @@ class Dictionary(ABC, nn.Module):
         Encode a vector x in the activation space.
         """
         pass
-    
+
     @abstractmethod
     def decode(self, f):
         """
@@ -41,6 +43,7 @@ class AutoEncoder(Dictionary, nn.Module):
     """
     A one-layer autoencoder.
     """
+
     def __init__(self, activation_dim, dict_size):
         super().__init__()
         self.activation_dim = activation_dim
@@ -56,14 +59,13 @@ class AutoEncoder(Dictionary, nn.Module):
         ## set encoder and decoder weights
         self.encoder.weight = nn.Parameter(w.clone().T)
         self.decoder.weight = nn.Parameter(w.clone())
-        
 
     def encode(self, x):
         return nn.ReLU()(self.encoder(x - self.bias))
-    
+
     def decode(self, f):
         return self.decoder(f) + self.bias
-    
+
     def forward(self, x, output_features=False, ghost_mask=None):
         """
         Forward pass of an autoencoder.
@@ -71,20 +73,22 @@ class AutoEncoder(Dictionary, nn.Module):
         output_features : if True, return the encoded features as well as the decoded x
         ghost_mask : if not None, run this autoencoder in "ghost mode" where features are masked
         """
-        if ghost_mask is None: # normal mode
+        if ghost_mask is None:  # normal mode
             f = self.encode(x)
             x_hat = self.decode(f)
             if output_features:
                 return x_hat, f
             else:
                 return x_hat
-        
-        else: # ghost mode
+
+        else:  # ghost mode
             f_pre = self.encoder(x - self.bias)
             f_ghost = t.exp(f_pre) * ghost_mask.to(f_pre)
             f = nn.ReLU()(f_pre)
 
-            x_ghost = self.decoder(f_ghost) # note that this only applies the decoder weight matrix, no bias
+            x_ghost = self.decoder(
+                f_ghost
+            )  # note that this only applies the decoder weight matrix, no bias
             x_hat = self.decode(f)
             if output_features:
                 return x_hat, x_ghost, f
@@ -94,24 +98,26 @@ class AutoEncoder(Dictionary, nn.Module):
     def scale_biases(self, scale: float):
         self.encoder.bias.data *= scale
         self.bias.data *= scale
-    
+
     @classmethod
     def from_pretrained(cls, path, dtype=t.float, device=None):
         """
         Load a pretrained autoencoder from a file.
         """
         state_dict = t.load(path)
-        dict_size, activation_dim = state_dict['encoder.weight'].shape
+        dict_size, activation_dim = state_dict["encoder.weight"].shape
         autoencoder = cls(activation_dim, dict_size)
         autoencoder.load_state_dict(state_dict)
         if device is not None:
             autoencoder.to(dtype=dtype, device=device)
         return autoencoder
-            
+
+
 class IdentityDict(Dictionary, nn.Module):
     """
     An identity dictionary, i.e. the identity function.
     """
+
     def __init__(self, activation_dim=None):
         super().__init__()
         self.activation_dim = activation_dim
@@ -119,28 +125,30 @@ class IdentityDict(Dictionary, nn.Module):
 
     def encode(self, x):
         return x
-    
+
     def decode(self, f):
         return f
-    
+
     def forward(self, x, output_features=False, ghost_mask=None):
         if output_features:
             return x, x
         else:
             return x
-        
+
     @classmethod
     def from_pretrained(cls, path, dtype=t.float, device=None):
         """
         Load a pretrained dictionary from a file.
         """
         return cls(None)
-        
+
+
 class GatedAutoEncoder(Dictionary, nn.Module):
     """
     An autoencoder with separate gating and magnitude networks.
     """
-    def __init__(self, activation_dim, dict_size, initialization='default', device=None):
+
+    def __init__(self, activation_dim, dict_size, initialization="default", device=None):
         super().__init__()
         self.activation_dim = activation_dim
         self.dict_size = dict_size
@@ -150,7 +158,7 @@ class GatedAutoEncoder(Dictionary, nn.Module):
         self.gate_bias = nn.Parameter(t.empty(dict_size, device=device))
         self.mag_bias = nn.Parameter(t.empty(dict_size, device=device))
         self.decoder = nn.Linear(dict_size, activation_dim, bias=False, device=device)
-        if initialization == 'default':
+        if initialization == "default":
             self._reset_parameters()
         else:
             initialization(self)
@@ -200,7 +208,7 @@ class GatedAutoEncoder(Dictionary, nn.Module):
         # Normalizing after encode, and renormalizing before decode to enable comparability
         f = f / self.decoder.weight.norm(dim=0, keepdim=True)
         return self.decoder(f) + self.decoder_bias
-    
+
     def forward(self, x, output_features=False):
         f = self.encode(x)
         x_hat = self.decode(f)
@@ -222,20 +230,20 @@ class GatedAutoEncoder(Dictionary, nn.Module):
         Load a pretrained autoencoder from a file.
         """
         state_dict = t.load(path)
-        dict_size, activation_dim = state_dict['encoder.weight'].shape
+        dict_size, activation_dim = state_dict["encoder.weight"].shape
         autoencoder = GatedAutoEncoder(activation_dim, dict_size)
         autoencoder.load_state_dict(state_dict)
         if device is not None:
             autoencoder.to(device)
         return autoencoder
 
-    
+
 class JumpReluAutoEncoder(Dictionary, nn.Module):
     """
     An autoencoder with jump ReLUs.
     """
 
-    def __init__(self, activation_dim, dict_size, device='cpu'):
+    def __init__(self, activation_dim, dict_size, device="cpu"):
         super().__init__()
         self.activation_dim = activation_dim
         self.dict_size = dict_size
@@ -264,11 +272,11 @@ class JumpReluAutoEncoder(Dictionary, nn.Module):
             return f, pre_jump
         else:
             return f
-        
+
     def decode(self, f):
         f = f / self.W_dec.norm(dim=1)
         return f @ self.W_dec + self.b_dec
-    
+
     def forward(self, x, output_features=False):
         """
         Forward pass of an autoencoder.
@@ -286,15 +294,15 @@ class JumpReluAutoEncoder(Dictionary, nn.Module):
         self.b_dec.data *= scale
         self.b_enc.data *= scale
         self.threshold.data *= scale
-    
+
     @classmethod
     def from_pretrained(
-            cls,
-            path: str | None = None, 
-            load_from_sae_lens: bool = False,
-            dtype: t.dtype = t.float32,
-            device: t.device | None = None,
-            **kwargs,
+        cls,
+        path: str | None = None,
+        load_from_sae_lens: bool = False,
+        dtype: t.dtype = t.float32,
+        device: t.device | None = None,
+        **kwargs,
     ):
         """
         Load a pretrained autoencoder from a file.
@@ -303,14 +311,17 @@ class JumpReluAutoEncoder(Dictionary, nn.Module):
         """
         if not load_from_sae_lens:
             state_dict = t.load(path)
-            activation_dim, dict_size = state_dict['W_enc'].shape
+            activation_dim, dict_size = state_dict["W_enc"].shape
             autoencoder = JumpReluAutoEncoder(activation_dim, dict_size)
             autoencoder.load_state_dict(state_dict)
             autoencoder = autoencoder.to(dtype=dtype, device=device)
         else:
             from sae_lens import SAE
+
             sae, cfg_dict, _ = SAE.from_pretrained(**kwargs)
-            assert cfg_dict["finetuning_scaling_factor"] == False, "Finetuning scaling factor not supported"
+            assert (
+                cfg_dict["finetuning_scaling_factor"] == False
+            ), "Finetuning scaling factor not supported"
             dict_size, activation_dim = cfg_dict["d_sae"], cfg_dict["d_in"]
             autoencoder = JumpReluAutoEncoder(activation_dim, dict_size, device=device)
             autoencoder.load_state_dict(sae.state_dict())
@@ -320,11 +331,13 @@ class JumpReluAutoEncoder(Dictionary, nn.Module):
             device = autoencoder.W_enc.device
         return autoencoder.to(dtype=dtype, device=device)
 
+
 # TODO merge this with AutoEncoder
 class AutoEncoderNew(Dictionary, nn.Module):
     """
     The autoencoder architecture and initialization used in https://transformer-circuits.pub/2024/april-update/index.html#training-saes
     """
+
     def __init__(self, activation_dim, dict_size):
         super().__init__()
         self.activation_dim = activation_dim
@@ -346,10 +359,10 @@ class AutoEncoderNew(Dictionary, nn.Module):
 
     def encode(self, x):
         return nn.ReLU()(self.encoder(x))
-    
+
     def decode(self, f):
         return self.decoder(f)
-    
+
     def forward(self, x, output_features=False):
         """
         Forward pass of an autoencoder.
@@ -357,19 +370,19 @@ class AutoEncoderNew(Dictionary, nn.Module):
         """
         if not output_features:
             return self.decode(self.encode(x))
-        else: # TODO rewrite so that x_hat depends on f
+        else:  # TODO rewrite so that x_hat depends on f
             f = self.encode(x)
             x_hat = self.decode(f)
             # multiply f by decoder column norms
             f = f * self.decoder.weight.norm(dim=0, keepdim=True)
             return x_hat, f
-            
+
     def from_pretrained(path, device=None):
         """
         Load a pretrained autoencoder from a file.
         """
         state_dict = t.load(path)
-        dict_size, activation_dim = state_dict['encoder.weight'].shape
+        dict_size, activation_dim = state_dict["encoder.weight"].shape
         autoencoder = AutoEncoderNew(activation_dim, dict_size)
         autoencoder.load_state_dict(state_dict)
         if device is not None:

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -19,31 +19,31 @@ from dictionary_learning.evaluation import evaluate
 
 EXPECTED_RESULTS = {
     "AutoEncoderTopK": {
-        "l2_loss": 4.325331306457519,
-        "l1_loss": 47.92763671875,
+        "l2_loss": 4.362327718734742,
+        "l1_loss": 50.94957427978515,
         "l0": 40.0,
-        "frac_variance_explained": 0.9584966480731965,
-        "cossim": 0.948570293188095,
-        "l2_ratio": 0.94872345328331,
-        "relative_reconstruction_bias": 0.9998040139675141,
-        "loss_original": 3.328495955467224,
-        "loss_reconstructed": 3.819682216644287,
-        "loss_zero": 13.250199031829833,
-        "frac_recovered": 0.9503251194953919,
+        "frac_variance_explained": 0.9578053653240204,
+        "cossim": 0.9478691875934601,
+        "l2_ratio": 0.9478908002376556,
+        "relative_reconstruction_bias": 0.999762898683548,
+        "loss_original": 3.3361297130584715,
+        "loss_reconstructed": 3.8404462814331053,
+        "loss_zero": 13.251659297943116,
+        "frac_recovered": 0.948982036113739,
         "frac_alive": 0.99951171875,
     },
     "AutoEncoder": {
-        "l2_loss": 6.822399997711182,
-        "l1_loss": 19.381900978088378,
-        "l0": 37.4492919921875,
-        "frac_variance_explained": 0.8993505954742431,
-        "cossim": 0.8791077017784119,
-        "l2_ratio": 0.7455410599708557,
-        "relative_reconstruction_bias": 0.9595056653022767,
-        "loss_original": 3.3284960985183716,
-        "loss_reconstructed": 5.203806638717651,
-        "loss_zero": 13.250199031829833,
-        "frac_recovered": 0.8104169845581055,
+        "l2_loss": 6.822444677352905,
+        "l1_loss": 19.382131576538086,
+        "l0": 37.45087890625,
+        "frac_variance_explained": 0.8993501663208008,
+        "cossim": 0.8791120409965515,
+        "l2_ratio": 0.74552041888237,
+        "relative_reconstruction_bias": 0.9595054805278778,
+        "loss_original": 3.3361297130584715,
+        "loss_reconstructed": 5.208198881149292,
+        "loss_zero": 13.251659297943116,
+        "frac_recovered": 0.8106247961521149,
         "frac_alive": 0.99658203125,
     },
 }
@@ -62,7 +62,7 @@ def test_sae_training():
     """End to end test for training an SAE. Takes ~2 minutes on an RTX 3090.
     This isn't a nice suite of unit tests, but it's better than nothing.
     I have observed that results can slightly vary with library versions. For full determinism,
-    use pytorch 2.2.0 and nnsight 0.3.3.
+    use pytorch 2.5.1 and nnsight 0.3.7.
 
     NOTE: `dictionary_learning` is meant to be used as a submodule. Thus, to run this test, you need to use `dictionary_learning` as a submodule
     and run the test from the root of the repository using `pytest -s`. Refer to https://github.com/adamkarvonen/dictionary_learning_demo for an example"""

--- a/trainers/batch_top_k.py
+++ b/trainers/batch_top_k.py
@@ -184,6 +184,8 @@ class BatchTopKTrainer(SAETrainer):
 
     def get_auxiliary_loss(self, x, x_reconstruct, acts):
         dead_features = self.num_tokens_since_fired >= self.dead_feature_threshold
+        self.dead_features = int(dead_features.sum())
+        
         if dead_features.sum() > 0:
             residual = x.float() - x_reconstruct.float()
             acts_topk_aux = t.topk(

--- a/trainers/jumprelu.py
+++ b/trainers/jumprelu.py
@@ -74,7 +74,6 @@ class JumpReluTrainer(nn.Module, SAETrainer):
         layer: int,
         lm_name: str,
         dict_class=JumpReluAutoEncoder,
-        # XXX: Training decay is not implemented
         seed: Optional[int] = None,
         # TODO: What's the default lr use in the paper?
         lr: float = 7e-5,
@@ -148,6 +147,9 @@ class JumpReluTrainer(nn.Module, SAETrainer):
         self.logging_parameters = []
 
     def loss(self, x: torch.Tensor, step: int, logging=False, **_):
+        # Note: We are using threshold, not log_threshold as in this notebook:
+        # https://colab.research.google.com/drive/1PlFzI_PWGTN9yCQLuBcSuPJUjgHL7GiD#scrollTo=yP828a6uIlSO
+        # I had poor results when using log_threshold and it would complicate the scale_biases() function
 
         if self.sparsity_warmup_steps is not None:
             sparsity_scale = min(step / self.sparsity_warmup_steps, 1.0)

--- a/trainers/matroyshka_batch_top_k.py
+++ b/trainers/matroyshka_batch_top_k.py
@@ -240,6 +240,7 @@ class MatroyshkaBatchTopKTrainer(SAETrainer):
 
     def get_auxiliary_loss(self, x, x_reconstruct, acts):
         dead_features = self.num_tokens_since_fired >= self.dead_feature_threshold
+        self.dead_features = int(dead_features.sum())
         if dead_features.sum() > 0:
             residual = x.float() - x_reconstruct.float()
             acts_topk_aux = t.topk(

--- a/trainers/matroyshka_batch_top_k.py
+++ b/trainers/matroyshka_batch_top_k.py
@@ -78,7 +78,8 @@ class MatroyshkaBatchTopKSAE(Dictionary, nn.Module):
     @t.no_grad()
     def set_decoder_norm_to_unit_norm(self):
         eps = t.finfo(self.W_dec.dtype).eps
-        norm = t.norm(self.W_dec.data, dim=0, keepdim=True)
+        norm = t.norm(self.W_dec.data, dim=1, keepdim=True)
+
         self.W_dec.data /= norm + eps
 
     @t.no_grad()

--- a/trainers/matroyshka_batch_top_k.py
+++ b/trainers/matroyshka_batch_top_k.py
@@ -1,0 +1,366 @@
+import torch as t
+import torch.nn as nn
+import torch.nn.functional as F
+import einops
+from collections import namedtuple
+from typing import Optional
+from math import isclose
+
+from ..dictionary import Dictionary
+from ..trainers.trainer import SAETrainer
+
+
+class MatroyshkaBatchTopKSAE(Dictionary, nn.Module):
+    def __init__(self, activation_dim: int, dict_size: int, k: int, group_sizes: list[int]):
+        super().__init__()
+        self.activation_dim = activation_dim
+        self.dict_size = dict_size
+
+        assert sum(group_sizes) == dict_size, "group sizes must sum to dict_size"
+        assert all(s > 0 for s in group_sizes), "all group sizes must be positive"
+
+        assert isinstance(k, int) and k > 0, f"k={k} must be a positive integer"
+        self.register_buffer("k", t.tensor(k))
+        self.register_buffer("threshold", t.tensor(-1.0))
+
+        self.group_sizes = group_sizes
+        self.active_groups = len(group_sizes)
+        group_indices = [0] + list(t.cumsum(t.tensor(group_sizes), dim=0))
+
+        self.register_buffer("group_indices", t.tensor(group_indices))
+
+        self.W_enc = nn.Parameter(t.empty(activation_dim, dict_size))
+        self.b_enc = nn.Parameter(t.zeros(dict_size))
+        self.W_dec = nn.Parameter(t.empty(dict_size, activation_dim))
+        self.b_dec = nn.Parameter(t.zeros(activation_dim))
+
+        self.W_dec.data = t.randn_like(self.W_dec)
+        self.set_decoder_norm_to_unit_norm()
+        self.W_enc.data = self.W_dec.data.clone().T
+
+    def encode(self, x: t.Tensor, return_active: bool = False, use_threshold: bool = True):
+        post_relu_feat_acts_BF = nn.functional.relu((x - self.b_dec) @ self.W_enc + self.b_enc)
+
+        if use_threshold:
+            encoded_acts_BF = post_relu_feat_acts_BF * (post_relu_feat_acts_BF > self.threshold)
+        else:
+            # Flatten and perform batch top-k
+            flattened_acts = post_relu_feat_acts_BF.flatten()
+            post_topk = flattened_acts.topk(self.k * x.size(0), sorted=False, dim=-1)
+
+            buffer_BF = t.zeros_like(post_relu_feat_acts_BF)
+            encoded_acts_BF = (
+                buffer_BF.flatten()
+                .scatter(-1, post_topk.indices, post_topk.values)
+                .reshape(buffer_BF.shape)
+            )
+
+        max_act_index = self.group_indices[self.active_groups]
+        encoded_acts_BF[:, max_act_index:] = 0
+
+        if return_active:
+            return encoded_acts_BF, encoded_acts_BF.sum(0) > 0
+        else:
+            return encoded_acts_BF
+
+    def decode(self, x: t.Tensor) -> t.Tensor:
+        return x @ self.W_dec + self.b_dec
+
+    def forward(self, x: t.Tensor, output_features: bool = False):
+        encoded_acts_BF = self.encode(x)
+        x_hat_BD = self.decode(encoded_acts_BF)
+
+        if not output_features:
+            return x_hat_BD
+        else:
+            return x_hat_BD, encoded_acts_BF
+
+    @t.no_grad()
+    def set_decoder_norm_to_unit_norm(self):
+        eps = t.finfo(self.W_dec.dtype).eps
+        norm = t.norm(self.W_dec.data, dim=0, keepdim=True)
+        self.W_dec.data /= norm + eps
+
+    @t.no_grad()
+    def remove_gradient_parallel_to_decoder_directions(self):
+        assert self.W_dec.grad is not None
+
+        parallel_component = einops.einsum(
+            self.W_dec.grad,
+            self.W_dec.data,
+            "d_sae d_in, d_sae d_in -> d_sae",
+        )
+        self.W_dec.grad -= einops.einsum(
+            parallel_component,
+            self.W_dec.data,
+            "d_sae, d_sae d_in -> d_sae d_in",
+        )
+
+    @t.no_grad()
+    def scale_biases(self, scale: float):
+        self.b_enc.data *= scale
+        self.b_dec.data *= scale
+        if self.threshold >= 0:
+            self.threshold *= scale
+
+    @classmethod
+    def from_pretrained(cls, path, k=None, device=None, **kwargs) -> "MatroyshkaBatchTopKSAE":
+        state_dict = t.load(path)
+        dict_size, activation_dim = state_dict["W_enc"].shape
+        if k is None:
+            k = state_dict["k"].item()
+        elif "k" in state_dict and k != state_dict["k"].item():
+            raise ValueError(f"k={k} != {state_dict['k'].item()}=state_dict['k']")
+
+        autoencoder = cls(activation_dim, dict_size, k)
+        autoencoder.load_state_dict(state_dict)
+        if device is not None:
+            autoencoder.to(device)
+        return autoencoder
+
+
+class MatroyshkaBatchTopKTrainer(SAETrainer):
+    def __init__(
+        self,
+        steps: int,  # total number of steps to train for
+        activation_dim: int,
+        dict_size: int,
+        k: int,
+        layer: int,
+        lm_name: str,
+        group_fractions: list[float],
+        group_weights: Optional[list[float]] = None,
+        dict_class: type = MatroyshkaBatchTopKSAE,
+        auxk_alpha: float = 1 / 32,
+        warmup_steps: int = 1000,
+        decay_start: Optional[int] = None,  # when does the lr decay start
+        threshold_beta: float = 0.999,
+        threshold_start_step: int = 1000,
+        top_k_aux: int = 512,
+        seed: Optional[int] = None,
+        device: Optional[str] = None,
+        wandb_name: str = "BatchTopKSAE",
+        submodule_name: Optional[str] = None,
+    ):
+        super().__init__(seed)
+        assert layer is not None and lm_name is not None
+        self.layer = layer
+        self.lm_name = lm_name
+        self.submodule_name = submodule_name
+        self.wandb_name = wandb_name
+        self.steps = steps
+        self.decay_start = decay_start
+        self.warmup_steps = warmup_steps
+        self.k = k
+        self.threshold_beta = threshold_beta
+        self.threshold_start_step = threshold_start_step
+
+        if seed is not None:
+            t.manual_seed(seed)
+            t.cuda.manual_seed_all(seed)
+
+        assert isclose(sum(group_fractions), 1.0), "group_fractions must sum to 1.0"
+        # Calculate all groups except the last one
+        group_sizes = [int(f * dict_size) for f in group_fractions[:-1]]
+        # Put remainder in the last group
+        group_sizes.append(dict_size - sum(group_sizes))
+
+        if group_weights is None:
+            group_weights = [1.0] * len(group_sizes)
+
+        assert len(group_sizes) == len(
+            group_weights
+        ), "group_sizes and group_weights must have the same length"
+
+        self.group_fractions = group_fractions
+        self.group_sizes = group_sizes
+        self.group_weights = group_weights
+
+        self.ae = dict_class(activation_dim, dict_size, k, group_sizes)
+
+        if device is None:
+            self.device = "cuda" if t.cuda.is_available() else "cpu"
+        else:
+            self.device = device
+        self.ae.to(self.device)
+
+        scale = dict_size / (2**14)
+        self.lr = 2e-4 / scale**0.5
+        self.auxk_alpha = auxk_alpha
+        self.dead_feature_threshold = 10_000_000
+        self.top_k_aux = top_k_aux
+
+        self.optimizer = t.optim.Adam(self.ae.parameters(), lr=self.lr, betas=(0.9, 0.999))
+
+        if decay_start is not None:
+            assert 0 <= decay_start < steps, "decay_start must be >= 0 and < steps."
+            assert decay_start > warmup_steps, "decay_start must be > warmup_steps."
+
+        assert 0 <= warmup_steps < steps, "warmup_steps must be >= 0 and < steps."
+
+        def lr_fn(step):
+            if step < warmup_steps:
+                return step / warmup_steps
+
+            if decay_start is not None and step >= decay_start:
+                return (steps - step) / (steps - decay_start)
+
+            return 1.0
+
+        self.scheduler = t.optim.lr_scheduler.LambdaLR(self.optimizer, lr_lambda=lr_fn)
+
+        self.num_tokens_since_fired = t.zeros(dict_size, dtype=t.long, device=device)
+        self.logging_parameters = ["effective_l0", "dead_features"]
+        self.effective_l0 = -1
+        self.dead_features = -1
+
+    def get_auxiliary_loss(self, x, x_reconstruct, acts):
+        dead_features = self.num_tokens_since_fired >= self.dead_feature_threshold
+        if dead_features.sum() > 0:
+            residual = x.float() - x_reconstruct.float()
+            acts_topk_aux = t.topk(
+                acts[:, dead_features],
+                min(self.top_k_aux, dead_features.sum()),
+                dim=-1,
+            )
+            acts_aux = t.zeros_like(acts[:, dead_features]).scatter(
+                -1, acts_topk_aux.indices, acts_topk_aux.values
+            )
+            x_reconstruct_aux = F.linear(acts_aux, self.ae.decoder.weight[:, dead_features])
+            l2_loss_aux = (
+                self.auxk_alpha * (x_reconstruct_aux.float() - residual.float()).pow(2).mean()
+            )
+            return l2_loss_aux
+        else:
+            return t.tensor(0, dtype=x.dtype, device=x.device)
+
+    def loss(self, x, step=None, logging=False):
+        f, active_indices = self.ae.encode(x, return_active=True, use_threshold=False)
+        # l0 = (f != 0).float().sum(dim=-1).mean().item()
+
+        if step > self.threshold_start_step:
+            with t.no_grad():
+                active = f[f > 0]
+
+                if active.size(0) == 0:
+                    min_activation = 0.0
+                else:
+                    min_activation = active.min().detach()
+
+                if self.ae.threshold < 0:
+                    self.ae.threshold = min_activation
+                else:
+                    self.ae.threshold = (self.threshold_beta * self.ae.threshold) + (
+                        (1 - self.threshold_beta) * min_activation
+                    )
+
+        x_reconstruct = t.zeros_like(x) + self.ae.b_dec
+        total_l2_loss = 0.0
+        l2_losses = t.tensor([]).to(self.device)
+
+        for i in range(self.ae.active_groups):
+            group_start = self.ae.group_indices[i]
+            group_end = self.ae.group_indices[i + 1]
+            W_dec_slice = self.ae.W_dec[group_start:group_end, :]
+            acts_slice = f[:, group_start:group_end]
+            x_reconstruct = x_reconstruct + acts_slice @ W_dec_slice
+
+            l2_loss = (x_reconstruct - x).pow(2).sum(dim=-1).mean() * self.group_weights[i]
+            total_l2_loss += l2_loss
+            l2_losses = t.cat([l2_losses, l2_loss.unsqueeze(0)])
+
+        min_l2_loss = l2_losses.min().item()
+        max_l2_loss = l2_losses.max().item()
+        mean_l2_loss = l2_losses.mean()
+
+        self.effective_l0 = self.k
+
+        num_tokens_in_step = x.size(0)
+        did_fire = t.zeros_like(self.num_tokens_since_fired, dtype=t.bool)
+        did_fire[active_indices] = True
+        self.num_tokens_since_fired += num_tokens_in_step
+        self.num_tokens_since_fired[did_fire] = 0
+
+        auxk_loss = self.get_auxiliary_loss(x, x_reconstruct, f)
+
+        auxk_loss = auxk_loss.sum(dim=-1).mean()
+        loss = mean_l2_loss + self.auxk_alpha * auxk_loss
+
+        if not logging:
+            return loss
+        else:
+            return namedtuple("LossLog", ["x", "x_hat", "f", "losses"])(
+                x,
+                x_reconstruct,
+                f,
+                {
+                    "l2_loss": mean_l2_loss.item(),
+                    "auxk_loss": auxk_loss.item(),
+                    "loss": loss.item(),
+                    "min_l2_loss": min_l2_loss,
+                    "max_l2_loss": max_l2_loss,
+                },
+            )
+
+    def update(self, step, x):
+        if step == 0:
+            median = self.geometric_median(x)
+            self.ae.b_dec.data = median
+
+        self.ae.set_decoder_norm_to_unit_norm()
+
+        x = x.to(self.device)
+        loss = self.loss(x, step=step)
+        loss.backward()
+
+        t.nn.utils.clip_grad_norm_(self.ae.parameters(), 1.0)
+        self.ae.remove_gradient_parallel_to_decoder_directions()
+
+        self.optimizer.step()
+        self.optimizer.zero_grad()
+        self.scheduler.step()
+
+        return loss.item()
+
+    @property
+    def config(self):
+        return {
+            "trainer_class": "MatroyshkaBatchTopKTrainer",
+            "dict_class": "MatroyshkaBatchTopKSAE",
+            "lr": self.lr,
+            "steps": self.steps,
+            "auxk_alpha": self.auxk_alpha,
+            "warmup_steps": self.warmup_steps,
+            "decay_start": self.decay_start,
+            "threshold_beta": self.threshold_beta,
+            "threshold_start_step": self.threshold_start_step,
+            "top_k_aux": self.top_k_aux,
+            "seed": self.seed,
+            "activation_dim": self.ae.activation_dim,
+            "dict_size": self.ae.dict_size,
+            "group_fractions": self.group_fractions,
+            "group_weights": self.group_weights,
+            "group_sizes": self.group_sizes,
+            "k": self.ae.k.item(),
+            "device": self.device,
+            "layer": self.layer,
+            "lm_name": self.lm_name,
+            "wandb_name": self.wandb_name,
+            "submodule_name": self.submodule_name,
+        }
+
+    @staticmethod
+    def geometric_median(points: t.Tensor, max_iter: int = 100, tol: float = 1e-5):
+        guess = points.mean(dim=0)
+        prev = t.zeros_like(guess)
+        weights = t.ones(len(points), device=points.device)
+
+        for _ in range(max_iter):
+            prev = guess
+            weights = 1 / t.norm(points - guess, dim=1)
+            weights /= weights.sum()
+            guess = (weights.unsqueeze(1) * points).sum(dim=0)
+            if t.norm(guess - prev) < tol:
+                break
+
+        return guess

--- a/trainers/top_k.py
+++ b/trainers/top_k.py
@@ -64,12 +64,12 @@ class AutoEncoderTopK(Dictionary, nn.Module):
         self.register_buffer("k", t.tensor(k))
         self.register_buffer("threshold", t.tensor(-1.0))
 
-        self.encoder = nn.Linear(activation_dim, dict_size)
-        self.encoder.bias.data.zero_()
-
         self.decoder = nn.Linear(dict_size, activation_dim, bias=False)
-        self.decoder.weight.data = self.encoder.weight.data.clone().T
         self.set_decoder_norm_to_unit_norm()
+
+        self.encoder = nn.Linear(activation_dim, dict_size)
+        self.encoder.weight.data = self.decoder.weight.T.clone()
+        self.encoder.bias.data.zero_()
 
         self.b_dec = nn.Parameter(t.zeros(activation_dim))
 
@@ -162,7 +162,7 @@ class TopKTrainer(SAETrainer):
 
     def __init__(
         self,
-        steps: int, # total number of steps to train for
+        steps: int,  # total number of steps to train for
         activation_dim: int,
         dict_size: int,
         k: int,
@@ -224,7 +224,7 @@ class TopKTrainer(SAETrainer):
         def lr_fn(step):
             if step < warmup_steps:
                 return step / warmup_steps
-            
+
             if decay_start is not None and step >= decay_start:
                 return (steps - step) / (steps - decay_start)
 

--- a/training.py
+++ b/training.py
@@ -187,6 +187,16 @@ def trainSAE(
             log_stats(
                 trainers, step, act, activations_split_by_head, transcoder, log_queues=log_queues
             )
+        if step % 100 == 0:
+            z = act.clone()
+            for i, trainer in enumerate(trainers):
+                act = z.clone()
+                act, act_hat, f, losslog = trainer.loss(act, step=step, logging=True)
+
+                # L0
+                l0 = (f != 0).float().sum(dim=-1).mean().item()
+
+                print(f"Step {step}: L0 = {l0}")
 
         # saving
         if save_steps is not None and step in save_steps:

--- a/training.py
+++ b/training.py
@@ -126,7 +126,9 @@ def trainSAE(
     """
 
     trainers = []
-    for config in trainer_configs:
+    for i, config in enumerate(trainer_configs):
+        if "wandb_name" in config:
+            config["wandb_name"] = f"{config['wandb_name']}_trainer_{i}"
         trainer_class = config["trainer"]
         del config["trainer"]
         trainers.append(trainer_class(**config))

--- a/utils.py
+++ b/utils.py
@@ -7,6 +7,7 @@ from nnsight import LanguageModel
 
 from dictionary_learning.trainers.top_k import AutoEncoderTopK
 from dictionary_learning.trainers.batch_top_k import BatchTopKSAE
+from dictionary_learning.trainers.matroyshka_batch_top_k import MatroyshkaBatchTopKSAE
 from dictionary_learning.dictionary import (
     AutoEncoder,
     GatedAutoEncoder,
@@ -74,7 +75,11 @@ def load_dictionary(base_path: str, device: str) -> tuple:
         k = config["trainer"]["k"]
         dictionary = AutoEncoderTopK.from_pretrained(ae_path, k=k, device=device)
     elif dict_class == "BatchTopKSAE":
-        dictionary = BatchTopKSAE.from_pretrained(ae_path, device=device)
+        k = config["trainer"]["k"]
+        dictionary = BatchTopKSAE.from_pretrained(ae_path, k=k, device=device)
+    elif dict_class == "MatroyshkaBatchTopKSAE":
+        k = config["trainer"]["k"]
+        dictionary = MatroyshkaBatchTopKSAE.from_pretrained(ae_path, k=k, device=device)
     elif dict_class == "JumpReluAutoEncoder":
         dictionary = JumpReluAutoEncoder.from_pretrained(ae_path, device=device)
     else:


### PR DESCRIPTION
A few updates in this PR:

- Added an implementation of the BatchTopK Matroyshka SAE
- Previously JumpReLU training did better than Standard but significantly worse than TopK. I fixed training so now it does slightly better than TopK.
- Previously our JumpReLU was initialized using torch.randn. I switched to using Kaiming initialization, following the procedure in the Gemma Scope paper. I also had TopK, BatchTopK, and Matroyshka use the same initialization procedure. In testing it seems like this made minimal difference.
- BatchTopK was multiplying the loss by aux_alpha twice, which isn't correct. I removed one of the multiplications.
- I made sure Gated W_dec was initialized as W_enc.T (it wasn't before).
- I added a flag to optionally remove BOS tokens from the Activation Buffer, and a verbose flag to optionally print L0 / frac variance explained during training
- I fixed a wandb logging bug that was causing random crashes