### PR TITLE
Consolidate LR Schedulers, Sparsity Schedulers, and constrained optimizers

### DIFF
--- a/dictionary.py
+++ b/dictionary.py
@@ -255,7 +255,7 @@ class JumpReluAutoEncoder(Dictionary, nn.Module):
             t.nn.init.kaiming_uniform_(t.empty(dict_size, activation_dim, device=device))
         )
         self.b_dec = nn.Parameter(t.zeros(activation_dim, device=device))
-        self.threshold = nn.Parameter(t.ones(dict_size, device=device) * 0.001) # Appendix I
+        self.threshold = nn.Parameter(t.ones(dict_size, device=device) * 0.001)  # Appendix I
 
         self.apply_b_dec_to_input = False
 
@@ -330,28 +330,6 @@ class JumpReluAutoEncoder(Dictionary, nn.Module):
         if device is not None:
             device = autoencoder.W_enc.device
         return autoencoder.to(dtype=dtype, device=device)
-
-    @t.no_grad()
-    def set_decoder_norm_to_unit_norm(self):
-        eps = t.finfo(self.W_dec.dtype).eps
-        norm = t.norm(self.W_dec.data, dim=1, keepdim=True)
-
-        self.W_dec.data /= norm + eps
-
-    @t.no_grad()
-    def remove_gradient_parallel_to_decoder_directions(self):
-        assert self.W_dec.grad is not None
-
-        parallel_component = einops.einsum(
-            self.W_dec.grad,
-            self.W_dec.data,
-            "d_sae d_in, d_sae d_in -> d_sae",
-        )
-        self.W_dec.grad -= einops.einsum(
-            parallel_component,
-            self.W_dec.data,
-            "d_sae, d_sae d_in -> d_sae d_in",
-        )
 
 
 # TODO merge this with AutoEncoder

--- a/trainers/batch_top_k.py
+++ b/trainers/batch_top_k.py
@@ -6,7 +6,12 @@ from collections import namedtuple
 from typing import Optional
 
 from ..dictionary import Dictionary
-from ..trainers.trainer import SAETrainer
+from ..trainers.trainer import (
+    SAETrainer,
+    get_lr_schedule,
+    set_decoder_norm_to_unit_norm,
+    remove_gradient_parallel_to_decoder_directions,
+)
 
 
 class BatchTopKSAE(Dictionary, nn.Module):
@@ -20,7 +25,9 @@ class BatchTopKSAE(Dictionary, nn.Module):
         self.register_buffer("threshold", t.tensor(-1.0))
 
         self.decoder = nn.Linear(dict_size, activation_dim, bias=False)
-        self.set_decoder_norm_to_unit_norm()
+        self.decoder.weight.data = set_decoder_norm_to_unit_norm(
+            self.decoder.weight, activation_dim, dict_size
+        )
 
         self.encoder = nn.Linear(activation_dim, dict_size)
         self.encoder.weight.data = self.decoder.weight.T.clone()
@@ -64,26 +71,6 @@ class BatchTopKSAE(Dictionary, nn.Module):
             return x_hat_BD
         else:
             return x_hat_BD, encoded_acts_BF
-
-    @t.no_grad()
-    def set_decoder_norm_to_unit_norm(self):
-        eps = t.finfo(self.decoder.weight.dtype).eps
-        norm = t.norm(self.decoder.weight.data, dim=0, keepdim=True)
-        self.decoder.weight.data /= norm + eps
-
-    @t.no_grad()
-    def remove_gradient_parallel_to_decoder_directions(self):
-        assert self.decoder.weight.grad is not None
-        parallel_component = einops.einsum(
-            self.decoder.weight.grad,
-            self.decoder.weight.data,
-            "d_in d_sae, d_in d_sae -> d_sae",
-        )
-        self.decoder.weight.grad -= einops.einsum(
-            parallel_component,
-            self.decoder.weight.data,
-            "d_sae, d_in d_sae -> d_in d_sae",
-        )
 
     def scale_biases(self, scale: float):
         self.encoder.bias.data *= scale
@@ -160,20 +147,7 @@ class BatchTopKTrainer(SAETrainer):
 
         self.optimizer = t.optim.Adam(self.ae.parameters(), lr=self.lr, betas=(0.9, 0.999))
 
-        if decay_start is not None:
-            assert 0 <= decay_start < steps, "decay_start must be >= 0 and < steps."
-            assert decay_start > warmup_steps, "decay_start must be > warmup_steps."
-
-        assert 0 <= warmup_steps < steps, "warmup_steps must be >= 0 and < steps."
-
-        def lr_fn(step):
-            if step < warmup_steps:
-                return step / warmup_steps
-
-            if decay_start is not None and step >= decay_start:
-                return (steps - step) / (steps - decay_start)
-
-            return 1.0
+        lr_fn = get_lr_schedule(steps, warmup_steps, decay_start=decay_start)
 
         self.scheduler = t.optim.lr_scheduler.LambdaLR(self.optimizer, lr_lambda=lr_fn)
 
@@ -185,7 +159,7 @@ class BatchTopKTrainer(SAETrainer):
     def get_auxiliary_loss(self, x, x_reconstruct, acts):
         dead_features = self.num_tokens_since_fired >= self.dead_feature_threshold
         self.dead_features = int(dead_features.sum())
-        
+
         if dead_features.sum() > 0:
             residual = x.float() - x_reconstruct.float()
             acts_topk_aux = t.topk(
@@ -255,14 +229,22 @@ class BatchTopKTrainer(SAETrainer):
             median = self.geometric_median(x)
             self.ae.b_dec.data = median
 
-        self.ae.set_decoder_norm_to_unit_norm()
+        # Make sure the decoder is still unit-norm
+        self.ae.decoder.weight.data = set_decoder_norm_to_unit_norm(
+            self.ae.decoder.weight, self.ae.activation_dim, self.ae.dict_size
+        )
 
         x = x.to(self.device)
         loss = self.loss(x, step=step)
         loss.backward()
 
         t.nn.utils.clip_grad_norm_(self.ae.parameters(), 1.0)
-        self.ae.remove_gradient_parallel_to_decoder_directions()
+        self.ae.decoder.weight.grad = remove_gradient_parallel_to_decoder_directions(
+            self.ae.decoder.weight,
+            self.ae.decoder.weight.grad,
+            self.ae.activation_dim,
+            self.ae.dict_size,
+        )
 
         self.optimizer.step()
         self.optimizer.zero_grad()

--- a/trainers/gated_anneal.py
+++ b/trainers/gated_anneal.py
@@ -5,30 +5,10 @@ Implements the training scheme for a gated SAE described in https://arxiv.org/ab
 import torch as t
 from typing import Optional
 
-from ..trainers.trainer import SAETrainer
+from ..trainers.trainer import SAETrainer, get_lr_schedule, get_sparsity_warmup_fn, ConstrainedAdam
 from ..config import DEBUG
 from ..dictionary import GatedAutoEncoder
 from collections import namedtuple
-
-class ConstrainedAdam(t.optim.Adam):
-    """
-    A variant of Adam where some of the parameters are constrained to have unit norm.
-    """
-    def __init__(self, params, constrained_params, lr):
-        super().__init__(params, lr=lr, betas=(0, 0.999))
-        self.constrained_params = list(constrained_params)
-    
-    def step(self, closure=None):
-        with t.no_grad():
-            for p in self.constrained_params:
-                normed_p = p / p.norm(dim=0, keepdim=True)
-                # project away the parallel component of the gradient
-                p.grad -= (p.grad * normed_p).sum(dim=0, keepdim=True) * normed_p
-        super().step(closure=closure)
-        with t.no_grad():
-            for p in self.constrained_params:
-                # renormalize the constrained parameters
-                p /= p.norm(dim=0, keepdim=True)
 
 class GatedAnnealTrainer(SAETrainer):
     """
@@ -116,33 +96,11 @@ class GatedAnnealTrainer(SAETrainer):
         else:
             self.steps_since_active = None 
 
-        self.optimizer = ConstrainedAdam(self.ae.parameters(), self.ae.decoder.parameters(), lr=lr)
+        self.optimizer = ConstrainedAdam(self.ae.parameters(), self.ae.decoder.parameters(), lr=lr, betas=(0.0, 0.999))
 
-        if decay_start is not None:
-            assert resample_steps is None, "decay_start and resample_steps are currently mutually exclusive."
-            assert 0 <= decay_start < steps, "decay_start must be >= 0 and < steps."
-            assert decay_start > warmup_steps, "decay_start must be > warmup_steps."
-            if sparsity_warmup_steps is not None:
-                assert decay_start > sparsity_warmup_steps, "decay_start must be > sparsity_warmup_steps."
-
-        assert 0 <= warmup_steps < anneal_start, "warmup_steps must be >= 0 and < anneal_start."
-
-        if sparsity_warmup_steps is not None:
-            assert 0 <= sparsity_warmup_steps < anneal_start, "sparsity_warmup_steps must be >= 0 and < anneal_start."
-
-        if resample_steps is None:
-            def warmup_fn(step):
-                if step < warmup_steps:
-                    return step / warmup_steps
-                
-                if decay_start is not None and step >= decay_start:
-                    return (steps - step) / (steps - decay_start)
-
-                return 1.0
-        else:
-            def warmup_fn(step):
-                return min((step % resample_steps) / warmup_steps, 1.)
-        self.scheduler = t.optim.lr_scheduler.LambdaLR(self.optimizer, lr_lambda=warmup_fn)
+        lr_fn = get_lr_schedule(steps, warmup_steps, decay_start, resample_steps, sparsity_warmup_steps)
+        self.scheduler = t.optim.lr_scheduler.LambdaLR(self.optimizer, lr_lambda=lr_fn)
+        self.sparsity_warmup_fn = get_sparsity_warmup_fn(steps, sparsity_warmup_steps)
         
     def resample_neurons(self, deads, activations):
         with t.no_grad():
@@ -186,10 +144,7 @@ class GatedAnnealTrainer(SAETrainer):
             raise ValueError("Sparsity function must be 'Lp' or 'Lp^p'")
         
     def loss(self, x:t.Tensor, step:int, logging=False, **kwargs):
-        if self.sparsity_warmup_steps is not None:
-            sparsity_scale = min(step / self.sparsity_warmup_steps, 1.0)
-        else:
-            sparsity_scale = 1.0
+        sparsity_scale = self.sparsity_warmup_fn(step)
         f, f_gate = self.ae.encode(x, return_gate=True)
         x_hat = self.ae.decode(f)
         x_hat_gate = f_gate @ self.ae.decoder.weight.detach().T + self.ae.decoder_bias.detach()

--- a/trainers/gdm.py
+++ b/trainers/gdm.py
@@ -5,30 +5,10 @@ Implements the training scheme for a gated SAE described in https://arxiv.org/ab
 import torch as t
 from typing import Optional
 
-from ..trainers.trainer import SAETrainer
+from ..trainers.trainer import SAETrainer, get_lr_schedule, get_sparsity_warmup_fn, ConstrainedAdam
 from ..config import DEBUG
 from ..dictionary import GatedAutoEncoder
 from collections import namedtuple
-
-class ConstrainedAdam(t.optim.Adam):
-    """
-    A variant of Adam where some of the parameters are constrained to have unit norm.
-    """
-    def __init__(self, params, constrained_params, lr):
-        super().__init__(params, lr=lr, betas=(0, 0.999))
-        self.constrained_params = list(constrained_params)
-    
-    def step(self, closure=None):
-        with t.no_grad():
-            for p in self.constrained_params:
-                normed_p = p / p.norm(dim=0, keepdim=True)
-                # project away the parallel component of the gradient
-                p.grad -= (p.grad * normed_p).sum(dim=0, keepdim=True) * normed_p
-        super().step(closure=closure)
-        with t.no_grad():
-            for p in self.constrained_params:
-                # renormalize the constrained parameters
-                p /= p.norm(dim=0, keepdim=True)
 
 class GatedSAETrainer(SAETrainer):
     """
@@ -81,37 +61,19 @@ class GatedSAETrainer(SAETrainer):
         self.optimizer = ConstrainedAdam(
             self.ae.parameters(),
             self.ae.decoder.parameters(),
-            lr=lr
+            lr=lr,
+            betas=(0.0, 0.999),
         )
 
-        if decay_start is not None:
-            assert 0 <= decay_start < steps, "decay_start must be >= 0 and < steps."
-            assert decay_start > warmup_steps, "decay_start must be > warmup_steps."
-            if sparsity_warmup_steps is not None:
-                assert decay_start > sparsity_warmup_steps, "decay_start must be > sparsity_warmup_steps."
+        lr_fn = get_lr_schedule(steps, warmup_steps, decay_start, resample_steps=None, sparsity_warmup_steps=sparsity_warmup_steps)
 
-        assert 0 <= warmup_steps < steps, "warmup_steps must be >= 0 and < steps."
+        self.scheduler = t.optim.lr_scheduler.LambdaLR(self.optimizer, lr_fn)
+        self.sparsity_warmup_fn = get_sparsity_warmup_fn(steps, sparsity_warmup_steps)
 
-        if sparsity_warmup_steps is not None:
-            assert 0 <= sparsity_warmup_steps < steps, "sparsity_warmup_steps must be >= 0 and < steps."
-
-        def warmup_fn(step):
-            if step < warmup_steps:
-                return step / warmup_steps
-            
-            if decay_start is not None and step >= decay_start:
-                return (steps - step) / (steps - decay_start)
-
-            return 1.0
-
-        self.scheduler = t.optim.lr_scheduler.LambdaLR(self.optimizer, warmup_fn)
 
     def loss(self, x:t.Tensor, step:int, logging:bool=False, **kwargs):
 
-        if self.sparsity_warmup_steps is not None:
-            sparsity_scale = min(step / self.sparsity_warmup_steps, 1.0)
-        else:
-            sparsity_scale = 1.0
+        sparsity_scale = self.sparsity_warmup_fn(step)
 
         f, f_gate = self.ae.encode(x, return_gate=True)
         x_hat = self.ae.decode(f)

--- a/trainers/jumprelu.py
+++ b/trainers/jumprelu.py
@@ -6,7 +6,14 @@ from torch import nn
 from typing import Optional
 
 from ..dictionary import Dictionary, JumpReluAutoEncoder
-from .trainer import SAETrainer
+from ..trainers.trainer import (
+    SAETrainer,
+    get_lr_schedule,
+    get_sparsity_warmup_fn,
+    set_decoder_norm_to_unit_norm,
+    remove_gradient_parallel_to_decoder_directions,
+)
+
 
 class RectangleFunction(autograd.Function):
     @staticmethod
@@ -31,7 +38,7 @@ class JumpReLUFunction(autograd.Function):
     @staticmethod
     def backward(ctx, grad_output):
         x, threshold, bandwidth_tensor = ctx.saved_tensors
-        bandwidth = bandwidth_tensor.item() 
+        bandwidth = bandwidth_tensor.item()
         x_grad = (x > threshold).float() * grad_output
         threshold_grad = (
             -(threshold / bandwidth)
@@ -53,9 +60,7 @@ class StepFunction(autograd.Function):
         bandwidth = bandwidth_tensor.item()
         x_grad = torch.zeros_like(x)
         threshold_grad = (
-            -(1.0 / bandwidth)
-            * RectangleFunction.apply((x - threshold) / bandwidth)
-            * grad_output
+            -(1.0 / bandwidth) * RectangleFunction.apply((x - threshold) / bandwidth) * grad_output
         )
         return x_grad, threshold_grad, None  # None for bandwidth
 
@@ -66,9 +71,10 @@ class JumpReluTrainer(nn.Module, SAETrainer):
 
     Note does not use learning rate or sparsity scheduling as in the paper.
     """
+
     def __init__(
         self,
-        steps: int, # total number of steps to train for
+        steps: int,  # total number of steps to train for
         activation_dim: int,
         dict_size: int,
         layer: int,
@@ -79,9 +85,9 @@ class JumpReluTrainer(nn.Module, SAETrainer):
         lr: float = 7e-5,
         bandwidth: float = 0.001,
         sparsity_penalty: float = 1.0,
-        warmup_steps:int=1000, # lr warmup period at start of training and after each resample
-        sparsity_warmup_steps:Optional[int]=2000, # sparsity warmup period at start of training
-        decay_start:Optional[int]=None, # decay learning rate after this many steps
+        warmup_steps: int = 1000,  # lr warmup period at start of training and after each resample
+        sparsity_warmup_steps: Optional[int] = 2000,  # sparsity warmup period at start of training
+        decay_start: Optional[int] = None,  # decay learning rate after this many steps
         target_l0: float = 20.0,
         device: str = "cpu",
         wandb_name: str = "JumpRelu",
@@ -118,31 +124,19 @@ class JumpReluTrainer(nn.Module, SAETrainer):
         ).to(self.device)
 
         # Parameters from the paper
-        self.optimizer = torch.optim.Adam(
-            self.ae.parameters(), lr=lr, betas=(0.0, 0.999), eps=1e-8
+        self.optimizer = torch.optim.Adam(self.ae.parameters(), lr=lr, betas=(0.0, 0.999), eps=1e-8)
+
+        lr_fn = get_lr_schedule(
+            steps,
+            warmup_steps,
+            decay_start,
+            resample_steps=None,
+            sparsity_warmup_steps=sparsity_warmup_steps,
         )
 
-        if decay_start is not None:
-            assert 0 <= decay_start < steps, "decay_start must be >= 0 and < steps."
-            assert decay_start > warmup_steps, "decay_start must be > warmup_steps."
-            if sparsity_warmup_steps is not None:
-                assert decay_start > sparsity_warmup_steps, "decay_start must be > sparsity_warmup_steps."
+        self.scheduler = torch.optim.lr_scheduler.LambdaLR(self.optimizer, lr_lambda=lr_fn)
 
-        assert 0 <= warmup_steps < steps, "warmup_steps must be >= 0 and < steps."
-
-        if sparsity_warmup_steps is not None:
-            assert 0 <= sparsity_warmup_steps < steps, "sparsity_warmup_steps must be >= 0 and < steps."
-
-        def warmup_fn(step):
-            if step < warmup_steps:
-                return step / warmup_steps
-            
-            if decay_start is not None and step >= decay_start:
-                return (steps - step) / (steps - decay_start)
-
-            return 1.0
-        
-        self.scheduler = torch.optim.lr_scheduler.LambdaLR(self.optimizer, lr_lambda=warmup_fn)
+        self.sparsity_warmup_fn = get_sparsity_warmup_fn(steps, sparsity_warmup_steps)
 
         # Purely for logging purposes
         self.dead_feature_threshold = 10_000_000
@@ -155,10 +149,7 @@ class JumpReluTrainer(nn.Module, SAETrainer):
         # https://colab.research.google.com/drive/1PlFzI_PWGTN9yCQLuBcSuPJUjgHL7GiD#scrollTo=yP828a6uIlSO
         # I had poor results when using log_threshold and it would complicate the scale_biases() function
 
-        if self.sparsity_warmup_steps is not None:
-            sparsity_scale = min(step / self.sparsity_warmup_steps, 1.0)
-        else:
-            sparsity_scale = 1.0
+        sparsity_scale = self.sparsity_warmup_fn(step)
 
         pre_jump = x @ self.ae.W_enc + self.ae.b_enc
         f = JumpReLUFunction.apply(pre_jump, self.ae.threshold, self.bandwidth)
@@ -168,14 +159,18 @@ class JumpReluTrainer(nn.Module, SAETrainer):
         did_fire[active_indices] = True
         self.num_tokens_since_fired += x.size(0)
         self.num_tokens_since_fired[active_indices] = 0
-        self.dead_features = (self.num_tokens_since_fired > self.dead_feature_threshold).sum().item()
+        self.dead_features = (
+            (self.num_tokens_since_fired > self.dead_feature_threshold).sum().item()
+        )
 
         recon = self.ae.decode(f)
 
         recon_loss = (x - recon).pow(2).sum(dim=-1).mean()
         l0 = StepFunction.apply(f, self.ae.threshold, self.bandwidth).sum(dim=-1).mean()
 
-        sparsity_loss = self.sparsity_coefficient * ((l0 / self.target_l0) - 1).pow(2) * sparsity_scale
+        sparsity_loss = (
+            self.sparsity_coefficient * ((l0 / self.target_l0) - 1).pow(2) * sparsity_scale
+        )
         loss = recon_loss + sparsity_loss
 
         if not logging:
@@ -192,14 +187,20 @@ class JumpReluTrainer(nn.Module, SAETrainer):
             )
 
     def update(self, step, x):
-        self.ae.set_decoder_norm_to_unit_norm()
+        # We must transpose because we are using nn.Parameter, not nn.Linear
+        self.ae.W_dec.data = set_decoder_norm_to_unit_norm(
+            self.ae.W_dec.T, self.ae.activation_dim, self.ae.dict_size
+        ).T
 
         x = x.to(self.device)
         loss = self.loss(x, step=step)
         loss.backward()
 
         torch.nn.utils.clip_grad_norm_(self.ae.parameters(), 1.0)
-        self.ae.remove_gradient_parallel_to_decoder_directions()
+        # We must transpose because we are using nn.Parameter, not nn.Linear
+        self.ae.W_dec.grad = remove_gradient_parallel_to_decoder_directions(
+            self.ae.W_dec.T, self.ae.W_dec.grad.T, self.ae.activation_dim, self.ae.dict_size
+        ).T
 
         self.optimizer.step()
         self.scheduler.step()

--- a/trainers/p_anneal.py
+++ b/trainers/p_anneal.py
@@ -5,28 +5,8 @@ Implements the standard SAE training scheme.
 """
 
 from ..dictionary import AutoEncoder
-from ..trainers.trainer import SAETrainer
+from ..trainers.trainer import SAETrainer, get_lr_schedule, get_sparsity_warmup_fn, ConstrainedAdam
 from ..config import DEBUG
-
-class ConstrainedAdam(t.optim.Adam):
-    """
-    A variant of Adam where some of the parameters are constrained to have unit norm.
-    """
-    def __init__(self, params, constrained_params, lr):
-        super().__init__(params, lr=lr)
-        self.constrained_params = list(constrained_params)
-    
-    def step(self, closure=None):
-        with t.no_grad():
-            for p in self.constrained_params:
-                normed_p = p / p.norm(dim=0, keepdim=True)
-                # project away the parallel component of the gradient
-                p.grad -= (p.grad * normed_p).sum(dim=0, keepdim=True) * normed_p
-        super().step(closure=closure)
-        with t.no_grad():
-            for p in self.constrained_params:
-                # renormalize the constrained parameters
-                p /= p.norm(dim=0, keepdim=True)
 
 class PAnnealTrainer(SAETrainer):
     """
@@ -116,31 +96,10 @@ class PAnnealTrainer(SAETrainer):
 
         self.optimizer = ConstrainedAdam(self.ae.parameters(), self.ae.decoder.parameters(), lr=lr)
 
-        if decay_start is not None:
-            assert resample_steps is None, "decay_start and resample_steps are currently mutually exclusive."
-            assert 0 <= decay_start < steps, "decay_start must be >= 0 and < steps."
-            assert decay_start > warmup_steps, "decay_start must be > warmup_steps."
-            if sparsity_warmup_steps is not None:
-                assert decay_start > sparsity_warmup_steps, "decay_start must be > sparsity_warmup_steps."
+        lr_fn = get_lr_schedule(steps, warmup_steps, decay_start, resample_steps, sparsity_warmup_steps)
+        self.scheduler = t.optim.lr_scheduler.LambdaLR(self.optimizer, lr_lambda=lr_fn)
 
-        assert 0 <= warmup_steps < anneal_start, "warmup_steps must be >= 0 and < anneal_start."
-
-        if sparsity_warmup_steps is not None:
-            assert 0 <= sparsity_warmup_steps < anneal_start, "sparsity_warmup_steps must be >= 0 and < anneal_start."
-
-        if resample_steps is None:
-            def warmup_fn(step):
-                if step < warmup_steps:
-                    return step / warmup_steps
-                
-                if decay_start is not None and step >= decay_start:
-                    return (steps - step) / (steps - decay_start)
-
-                return 1.0
-        else:
-            def warmup_fn(step):
-                return min((step % resample_steps) / warmup_steps, 1.)
-        self.scheduler = t.optim.lr_scheduler.LambdaLR(self.optimizer, lr_lambda=warmup_fn)
+        self.sparsity_warmup_fn = get_sparsity_warmup_fn(steps, sparsity_warmup_steps)
         
         if (self.sparsity_update_steps.unique(return_counts=True)[1] >1).any():
             print("Warning! Duplicates om self.sparsity_update_steps detected!")
@@ -187,10 +146,7 @@ class PAnnealTrainer(SAETrainer):
             raise ValueError("Sparsity function must be 'Lp' or 'Lp^p'")
     
     def loss(self, x: t.Tensor, step:int, logging=False):
-        if self.sparsity_warmup_steps is not None:
-            sparsity_scale = min(step / self.sparsity_warmup_steps, 1.0)
-        else:
-            sparsity_scale = 1.0
+        sparsity_scale = self.sparsity_warmup_fn(step)
 
         # Compute loss terms
         x_hat, f = self.ae(x, output_features=True)

--- a/trainers/trainer.py
+++ b/trainers/trainer.py
@@ -1,16 +1,23 @@
+from typing import Optional, Callable
+import torch
+import einops
+
+
 class SAETrainer:
     """
     Generic class for implementing SAE training algorithms
     """
+
     def __init__(self, seed=None):
         self.seed = seed
         self.logging_parameters = []
 
-    def update(self, 
-               step, # index of step in training
-               activations, # of shape [batch_size, d_submodule]
-        ):
-        pass # implemented by subclasses
+    def update(
+        self,
+        step,  # index of step in training
+        activations,  # of shape [batch_size, d_submodule]
+    ):
+        pass  # implemented by subclasses
 
     def get_logging_parameters(self):
         stats = {}
@@ -20,9 +27,165 @@ class SAETrainer:
             else:
                 print(f"Warning: {param} not found in {self}")
         return stats
-    
+
     @property
     def config(self):
         return {
-            'wandb_name': 'trainer',
+            "wandb_name": "trainer",
         }
+
+
+class ConstrainedAdam(torch.optim.Adam):
+    """
+    A variant of Adam where some of the parameters are constrained to have unit norm.
+    Note: This should be used with a decoder that is nn.Linear, not nn.Parameter.
+    If nn.Parameter, the dim argument to norm should be 1.
+    """
+
+    def __init__(self, params, constrained_params, lr: float, betas: tuple[float, float] = (0.9, 0.999)):
+        super().__init__(params, lr=lr, betas=betas)
+        self.constrained_params = list(constrained_params)
+
+    def step(self, closure=None):
+        with torch.no_grad():
+            for p in self.constrained_params:
+                normed_p = p / p.norm(dim=0, keepdim=True)
+                # project away the parallel component of the gradient
+                p.grad -= (p.grad * normed_p).sum(dim=0, keepdim=True) * normed_p
+        super().step(closure=closure)
+        with torch.no_grad():
+            for p in self.constrained_params:
+                # renormalize the constrained parameters
+                p /= p.norm(dim=0, keepdim=True)
+
+
+# The next two functions could be replaced with the ConstrainedAdam Optimizer
+@torch.no_grad()
+def set_decoder_norm_to_unit_norm(
+    W_dec_DF: torch.nn.Parameter, activation_dim: int, d_sae: int
+) -> torch.Tensor:
+    """There's a major footgun here: we use this with both nn.Linear and nn.Parameter decoders.
+    nn.Linear stores the decoder weights in a transposed format (d_model, d_sae). So, we pass the dimensions in
+    to catch this error."""
+
+    D, F = W_dec_DF.shape
+
+    assert D == activation_dim
+    assert F == d_sae
+
+    eps = torch.finfo(W_dec_DF.dtype).eps
+    norm = torch.norm(W_dec_DF.data, dim=0, keepdim=True)
+    W_dec_DF.data /= norm + eps
+    return W_dec_DF.data
+
+
+@torch.no_grad()
+def remove_gradient_parallel_to_decoder_directions(
+    W_dec_DF: torch.Tensor,
+    W_dec_DF_grad: torch.Tensor,
+    activation_dim: int,
+    d_sae: int,
+) -> torch.Tensor:
+    """There's a major footgun here: we use this with both nn.Linear and nn.Parameter decoders.
+    nn.Linear stores the decoder weights in a transposed format (d_model, d_sae). So, we pass the dimensions in
+    to catch this error."""
+
+    D, F = W_dec_DF.shape
+    assert D == activation_dim
+    assert F == d_sae
+
+    parallel_component = einops.einsum(
+        W_dec_DF_grad,
+        W_dec_DF,
+        "d_in d_sae, d_in d_sae -> d_sae",
+    )
+    W_dec_DF_grad -= einops.einsum(
+        parallel_component,
+        W_dec_DF,
+        "d_sae, d_in d_sae -> d_in d_sae",
+    )
+    return W_dec_DF_grad
+
+
+def get_lr_schedule(
+    total_steps: int,
+    warmup_steps: int,
+    decay_start: Optional[int] = None,
+    resample_steps: Optional[int] = None,
+    sparsity_warmup_steps: Optional[int] = None,
+) -> Callable[[int], float]:
+    """
+    Creates a learning rate schedule function with linear warmup followed by an optional decay phase.
+
+    Note: resample_steps creates a repeating warmup pattern instead of the standard phases, but
+    is rarely used in practice.
+
+    Args:
+        total_steps: Total number of training steps
+        warmup_steps: Steps for linear warmup from 0 to 1
+        decay_start: Optional step to begin linear decay to 0
+        resample_steps: Optional period for repeating warmup pattern
+        sparsity_warmup_steps: Used for validation with decay_start
+
+    Returns:
+        Function that computes LR scale factor for a given step
+    """
+    if decay_start is not None:
+        assert (
+            resample_steps is None
+        ), "decay_start and resample_steps are currently mutually exclusive."
+        assert 0 <= decay_start < total_steps, "decay_start must be >= 0 and < steps."
+        assert decay_start > warmup_steps, "decay_start must be > warmup_steps."
+        if sparsity_warmup_steps is not None:
+            assert (
+                decay_start > sparsity_warmup_steps
+            ), "decay_start must be > sparsity_warmup_steps."
+
+    assert 0 <= warmup_steps < total_steps, "warmup_steps must be >= 0 and < steps."
+
+    if resample_steps is None:
+
+        def lr_schedule(step: int) -> float:
+            if step < warmup_steps:
+                # Warm-up phase
+                return step / warmup_steps
+
+            if decay_start is not None and step >= decay_start:
+                # Decay phase
+                return (total_steps - step) / (total_steps - decay_start)
+
+            # Constant phase
+            return 1.0
+    else:
+        assert 0 < resample_steps < total_steps, "resample_steps must be > 0 and < steps."
+
+        def lr_schedule(step: int) -> float:
+            return min((step % resample_steps) / warmup_steps, 1.0)
+
+    return lr_schedule
+
+
+def get_sparsity_warmup_fn(
+    total_steps: int, sparsity_warmup_steps: Optional[int] = None
+) -> Callable[[int], float]:
+    """
+    Return a function that computes a scale factor for sparsity penalty at a given step.
+
+    If `sparsity_warmup_steps` is None or 0, returns 1.0 for all steps.
+    Otherwise, scales from 0.0 up to 1.0 across `sparsity_warmup_steps`.
+    """
+
+    if sparsity_warmup_steps is not None:
+        assert (
+            0 <= sparsity_warmup_steps < total_steps
+        ), "sparsity_warmup_steps must be >= 0 and < steps."
+
+    def scale_fn(step: int) -> float:
+        if not sparsity_warmup_steps:
+            # If it's None or zero, we just return 1.0
+            return 1.0
+        else:
+            # Gradually increase from 0.0 -> 1.0 as step goes from 0 -> sparsity_warmup_steps
+            return min(step / sparsity_warmup_steps, 1.0)
+
+    return scale_fn


### PR DESCRIPTION
We had a bunch of duplicated code for LR Schedulers, Sparsity Schedulers, and Constrained Optimizers. I checked that the end to end test had identical results before and after these changes.

I put the shared functions in trainers/trainer.py