### PR TITLE
Aux loss fixes, standardize decoder normalization

### DIFF
--- a/trainers/batch_top_k.py
+++ b/trainers/batch_top_k.py
@@ -39,24 +39,19 @@ class BatchTopKSAE(Dictionary, nn.Module):
 
         if use_threshold:
             encoded_acts_BF = post_relu_feat_acts_BF * (post_relu_feat_acts_BF > self.threshold)
-            if return_active:
-                return encoded_acts_BF, encoded_acts_BF.sum(0) > 0
-            else:
-                return encoded_acts_BF
+        else:
+            # Flatten and perform batch top-k
+            flattened_acts = post_relu_feat_acts_BF.flatten()
+            post_topk = flattened_acts.topk(self.k * x.size(0), sorted=False, dim=-1)
 
-        # Flatten and perform batch top-k
-        flattened_acts = post_relu_feat_acts_BF.flatten()
-        post_topk = flattened_acts.topk(self.k * x.size(0), sorted=False, dim=-1)
-
-        buffer_BF = t.zeros_like(post_relu_feat_acts_BF)
-        encoded_acts_BF = (
-            buffer_BF.flatten()
-            .scatter(-1, post_topk.indices, post_topk.values)
-            .reshape(buffer_BF.shape)
-        )
+            encoded_acts_BF = (
+                t.zeros_like(post_relu_feat_acts_BF.flatten())
+                .scatter_(-1, post_topk.indices, post_topk.values)
+                .reshape(post_relu_feat_acts_BF.shape)
+            )
 
         if return_active:
-            return encoded_acts_BF, encoded_acts_BF.sum(0) > 0
+            return encoded_acts_BF, encoded_acts_BF.sum(0) > 0, post_relu_feat_acts_BF
         else:
             return encoded_acts_BF
 
@@ -146,9 +141,15 @@ class BatchTopKTrainer(SAETrainer):
             # Auto-select LR using 1 / sqrt(d) scaling law from Figure 3 of the paper
             scale = dict_size / (2**14)
             self.lr = 2e-4 / scale**0.5
+
         self.auxk_alpha = auxk_alpha
         self.dead_feature_threshold = 10_000_000
         self.top_k_aux = activation_dim // 2  # Heuristic from B.1 of the paper
+        self.num_tokens_since_fired = t.zeros(dict_size, dtype=t.long, device=device)
+        self.logging_parameters = ["effective_l0", "dead_features", "pre_norm_aux_loss"]
+        self.effective_l0 = -1
+        self.dead_features = -1
+        self.pre_norm_aux_loss = -1
 
         self.optimizer = t.optim.Adam(self.ae.parameters(), lr=self.lr, betas=(0.9, 0.999))
 
@@ -156,68 +157,79 @@ class BatchTopKTrainer(SAETrainer):
 
         self.scheduler = t.optim.lr_scheduler.LambdaLR(self.optimizer, lr_lambda=lr_fn)
 
-        self.num_tokens_since_fired = t.zeros(dict_size, dtype=t.long, device=device)
-        self.logging_parameters = ["effective_l0", "dead_features"]
-        self.effective_l0 = -1
-        self.dead_features = -1
-
-    def get_auxiliary_loss(self, x, x_reconstruct, acts):
+    def get_auxiliary_loss(self, residual_BD: t.Tensor, post_relu_acts_BF: t.Tensor):
         dead_features = self.num_tokens_since_fired >= self.dead_feature_threshold
         self.dead_features = int(dead_features.sum())
 
         if dead_features.sum() > 0:
-            residual = x.float() - x_reconstruct.float()
-            acts_topk_aux = t.topk(
-                acts[:, dead_features],
-                min(self.top_k_aux, dead_features.sum()),
-                dim=-1,
+            k_aux = min(self.top_k_aux, dead_features.sum())
+
+            auxk_latents = t.where(dead_features[None], post_relu_acts_BF, -t.inf)
+
+            # Top-k dead latents
+            auxk_acts, auxk_indices = auxk_latents.topk(k_aux, sorted=False)
+
+            auxk_buffer_BF = t.zeros_like(post_relu_acts_BF)
+            auxk_acts_BF = auxk_buffer_BF.scatter_(dim=-1, index=auxk_indices, src=auxk_acts)
+
+            # Note: decoder(), not decode(), as we don't want to apply the bias
+            x_reconstruct_aux = self.ae.decoder(auxk_acts_BF)
+            l2_loss_aux = (
+                (residual_BD.float() - x_reconstruct_aux.float()).pow(2).sum(dim=-1).mean()
             )
-            acts_aux = t.zeros_like(acts[:, dead_features]).scatter(
-                -1, acts_topk_aux.indices, acts_topk_aux.values
-            )
-            x_reconstruct_aux = F.linear(acts_aux, self.ae.decoder.weight[:, dead_features])
-            l2_loss_aux = (x_reconstruct_aux.float() - residual.float()).pow(2).mean()
-            return l2_loss_aux
+
+            self.pre_norm_auxk_loss = l2_loss_aux
+
+            # normalization from OpenAI implementation: https://github.com/openai/sparse_autoencoder/blob/main/sparse_autoencoder/kernels.py#L614
+            residual_mu = residual_BD.mean(dim=0)[None, :].broadcast_to(residual_BD.shape)
+            loss_denom = (residual_BD.float() - residual_mu.float()).pow(2).sum(dim=-1).mean()
+            normalized_auxk_loss = l2_loss_aux / loss_denom
+
+            return normalized_auxk_loss
         else:
-            return t.tensor(0, dtype=x.dtype, device=x.device)
+            self.pre_norm_auxk_loss = -1
+            return t.tensor(0, dtype=residual_BD.dtype, device=residual_BD.device)
+
+    def update_threshold(self, f: t.Tensor):
+        device_type = "cuda" if f.is_cuda else "cpu"
+        with t.autocast(device_type=device_type, enabled=False), t.no_grad():
+            active = f[f > 0]
+
+            if active.size(0) == 0:
+                min_activation = 0.0
+            else:
+                min_activation = active.min().detach().to(dtype=t.float32)
+
+            if self.ae.threshold < 0:
+                self.ae.threshold = min_activation
+            else:
+                self.ae.threshold = (self.threshold_beta * self.ae.threshold) + (
+                    (1 - self.threshold_beta) * min_activation
+                )
 
     def loss(self, x, step=None, logging=False):
-        f, active_indices = self.ae.encode(x, return_active=True, use_threshold=False)
+        f, active_indices_F, post_relu_acts_BF = self.ae.encode(
+            x, return_active=True, use_threshold=False
+        )
         # l0 = (f != 0).float().sum(dim=-1).mean().item()
 
         if step > self.threshold_start_step:
-            device_type = 'cuda' if x.is_cuda else 'cpu'
-            with t.autocast(device_type=device_type, enabled=False), t.no_grad():
-                active = f[f > 0]
-
-                if active.size(0) == 0:
-                    min_activation = 0.0
-                else:
-                    min_activation = active.min().detach().to(dtype=t.float32)
-
-                if self.ae.threshold < 0:
-                    self.ae.threshold = min_activation
-                else:
-                    self.ae.threshold = (self.threshold_beta * self.ae.threshold) + (
-                        (1 - self.threshold_beta) * min_activation
-                    )
+            self.update_threshold(f)
 
         x_hat = self.ae.decode(f)
 
-        e = x_hat - x
+        e = x - x_hat
 
         self.effective_l0 = self.k
 
         num_tokens_in_step = x.size(0)
         did_fire = t.zeros_like(self.num_tokens_since_fired, dtype=t.bool)
-        did_fire[active_indices] = True
+        did_fire[active_indices_F] = True
         self.num_tokens_since_fired += num_tokens_in_step
         self.num_tokens_since_fired[did_fire] = 0
 
-        auxk_loss = self.get_auxiliary_loss(x, x_hat, f)
-
         l2_loss = e.pow(2).sum(dim=-1).mean()
-        auxk_loss = auxk_loss.sum(dim=-1).mean()
+        auxk_loss = self.get_auxiliary_loss(e, post_relu_acts_BF)
         loss = l2_loss + self.auxk_alpha * auxk_loss
 
         if not logging:

--- a/trainers/batch_top_k.py
+++ b/trainers/batch_top_k.py
@@ -236,26 +236,26 @@ class BatchTopKTrainer(SAETrainer):
             median = median.to(self.ae.b_dec.dtype)
             self.ae.b_dec.data = median
 
-        # Make sure the decoder is still unit-norm
-        self.ae.decoder.weight.data = set_decoder_norm_to_unit_norm(
-            self.ae.decoder.weight, self.ae.activation_dim, self.ae.dict_size
-        )
-
         x = x.to(self.device)
         loss = self.loss(x, step=step)
         loss.backward()
 
-        t.nn.utils.clip_grad_norm_(self.ae.parameters(), 1.0)
         self.ae.decoder.weight.grad = remove_gradient_parallel_to_decoder_directions(
             self.ae.decoder.weight,
             self.ae.decoder.weight.grad,
             self.ae.activation_dim,
             self.ae.dict_size,
         )
+        t.nn.utils.clip_grad_norm_(self.ae.parameters(), 1.0)
 
         self.optimizer.step()
         self.optimizer.zero_grad()
         self.scheduler.step()
+
+        # Make sure the decoder is still unit-norm
+        self.ae.decoder.weight.data = set_decoder_norm_to_unit_norm(
+            self.ae.decoder.weight, self.ae.activation_dim, self.ae.dict_size
+        )
 
         return loss.item()
 

--- a/trainers/matroyshka_batch_top_k.py
+++ b/trainers/matroyshka_batch_top_k.py
@@ -74,18 +74,17 @@ class MatroyshkaBatchTopKSAE(Dictionary, nn.Module):
             flattened_acts = post_relu_feat_acts_BF.flatten()
             post_topk = flattened_acts.topk(self.k * x.size(0), sorted=False, dim=-1)
 
-            buffer_BF = t.zeros_like(post_relu_feat_acts_BF)
             encoded_acts_BF = (
-                buffer_BF.flatten()
-                .scatter(-1, post_topk.indices, post_topk.values)
-                .reshape(buffer_BF.shape)
+                t.zeros_like(post_relu_feat_acts_BF.flatten())
+                .scatter_(-1, post_topk.indices, post_topk.values)
+                .reshape(post_relu_feat_acts_BF.shape)
             )
 
         max_act_index = self.group_indices[self.active_groups]
         encoded_acts_BF[:, max_act_index:] = 0
 
         if return_active:
-            return encoded_acts_BF, encoded_acts_BF.sum(0) > 0
+            return encoded_acts_BF, encoded_acts_BF.sum(0) > 0, post_relu_feat_acts_BF
         else:
             return encoded_acts_BF
 
@@ -207,50 +206,69 @@ class MatroyshkaBatchTopKTrainer(SAETrainer):
         self.scheduler = t.optim.lr_scheduler.LambdaLR(self.optimizer, lr_lambda=lr_fn)
 
         self.num_tokens_since_fired = t.zeros(dict_size, dtype=t.long, device=device)
-        self.logging_parameters = ["effective_l0", "dead_features"]
+        self.logging_parameters = ["effective_l0", "dead_features", "pre_norm_auxk_loss"]
         self.effective_l0 = -1
         self.dead_features = -1
+        self.pre_norm_auxk_loss = -1
 
-    def get_auxiliary_loss(self, x, x_reconstruct, acts):
+    def get_auxiliary_loss(self, residual_BD: t.Tensor, post_relu_acts_BF: t.Tensor):
         dead_features = self.num_tokens_since_fired >= self.dead_feature_threshold
         self.dead_features = int(dead_features.sum())
-        if dead_features.sum() > 0:
-            residual = x.float() - x_reconstruct.float()
-            acts_topk_aux = t.topk(
-                acts[:, dead_features],
-                min(self.top_k_aux, dead_features.sum()),
-                dim=-1,
-            )
-            acts_aux = t.zeros_like(acts[:, dead_features]).scatter(
-                -1, acts_topk_aux.indices, acts_topk_aux.values
-            )
-            x_reconstruct_aux = F.linear(acts_aux, self.ae.W_dec[dead_features, :].T)
-            l2_loss_aux = (x_reconstruct_aux.float() - residual.float()).pow(2).mean()
 
-            return l2_loss_aux
+        if self.dead_features > 0:
+            k_aux = min(self.top_k_aux, self.dead_features)
+
+            auxk_latents = t.where(dead_features[None], post_relu_acts_BF, -t.inf)
+
+            # Top-k dead latents
+            auxk_acts, auxk_indices = auxk_latents.topk(k_aux, sorted=False)
+
+            auxk_buffer_BF = t.zeros_like(post_relu_acts_BF)
+            auxk_acts_BF = auxk_buffer_BF.scatter_(dim=-1, index=auxk_indices, src=auxk_acts)
+
+            # We don't want to apply the bias
+            x_reconstruct_aux = auxk_acts_BF @ self.ae.W_dec
+            l2_loss_aux = (
+                (residual_BD.float() - x_reconstruct_aux.float()).pow(2).sum(dim=-1).mean()
+            )
+
+            self.pre_norm_auxk_loss = l2_loss_aux
+
+            # normalization from OpenAI implementation: https://github.com/openai/sparse_autoencoder/blob/main/sparse_autoencoder/kernels.py#L614
+            residual_mu = residual_BD.mean(dim=0)[None, :].broadcast_to(residual_BD.shape)
+            loss_denom = (residual_BD.float() - residual_mu.float()).pow(2).sum(dim=-1).mean()
+            normalized_auxk_loss = l2_loss_aux / loss_denom
+
+            return normalized_auxk_loss
         else:
-            return t.tensor(0, dtype=x.dtype, device=x.device)
+            self.pre_norm_auxk_loss = -1
+            return t.tensor(0, dtype=residual_BD.dtype, device=residual_BD.device)
+
+    def update_threshold(self, f: t.Tensor):
+        device_type = "cuda" if f.is_cuda else "cpu"
+        with t.autocast(device_type=device_type, enabled=False), t.no_grad():
+            active = f[f > 0]
+
+            if active.size(0) == 0:
+                min_activation = 0.0
+            else:
+                min_activation = active.min().detach().to(dtype=t.float32)
+
+            if self.ae.threshold < 0:
+                self.ae.threshold = min_activation
+            else:
+                self.ae.threshold = (self.threshold_beta * self.ae.threshold) + (
+                    (1 - self.threshold_beta) * min_activation
+                )
 
     def loss(self, x, step=None, logging=False):
-        f, active_indices = self.ae.encode(x, return_active=True, use_threshold=False)
+        f, active_indices_F, post_relu_acts_BF = self.ae.encode(
+            x, return_active=True, use_threshold=False
+        )
         # l0 = (f != 0).float().sum(dim=-1).mean().item()
 
         if step > self.threshold_start_step:
-            device_type = "cuda" if x.is_cuda else "cpu"
-            with t.autocast(device_type=device_type, enabled=False), t.no_grad():
-                active = f[f > 0]
-
-                if active.size(0) == 0:
-                    min_activation = 0.0
-                else:
-                    min_activation = active.min().detach().to(dtype=t.float32)
-
-                if self.ae.threshold < 0:
-                    self.ae.threshold = min_activation
-                else:
-                    self.ae.threshold = (self.threshold_beta * self.ae.threshold) + (
-                        (1 - self.threshold_beta) * min_activation
-                    )
+            self.update_threshold(f)
 
         x_reconstruct = t.zeros_like(x) + self.ae.b_dec
         total_l2_loss = 0.0
@@ -263,7 +281,7 @@ class MatroyshkaBatchTopKTrainer(SAETrainer):
             acts_slice = f[:, group_start:group_end]
             x_reconstruct = x_reconstruct + acts_slice @ W_dec_slice
 
-            l2_loss = (x_reconstruct - x).pow(2).sum(dim=-1).mean() * self.group_weights[i]
+            l2_loss = (x - x_reconstruct).pow(2).sum(dim=-1).mean() * self.group_weights[i]
             total_l2_loss += l2_loss
             l2_losses = t.cat([l2_losses, l2_loss.unsqueeze(0)])
 
@@ -275,13 +293,11 @@ class MatroyshkaBatchTopKTrainer(SAETrainer):
 
         num_tokens_in_step = x.size(0)
         did_fire = t.zeros_like(self.num_tokens_since_fired, dtype=t.bool)
-        did_fire[active_indices] = True
+        did_fire[active_indices_F] = True
         self.num_tokens_since_fired += num_tokens_in_step
         self.num_tokens_since_fired[did_fire] = 0
 
-        auxk_loss = self.get_auxiliary_loss(x, x_reconstruct, f)
-
-        auxk_loss = auxk_loss.sum(dim=-1).mean()
+        auxk_loss = self.get_auxiliary_loss((x - x_reconstruct), post_relu_acts_BF)
         loss = mean_l2_loss + self.auxk_alpha * auxk_loss
 
         if not logging:

--- a/trainers/top_k.py
+++ b/trainers/top_k.py
@@ -87,7 +87,7 @@ class AutoEncoderTopK(Dictionary, nn.Module):
             encoded_acts_BF = post_relu_feat_acts_BF * (post_relu_feat_acts_BF > self.threshold)
             if return_topk:
                 post_topk = post_relu_feat_acts_BF.topk(self.k, sorted=False, dim=-1)
-                return encoded_acts_BF, post_topk.values, post_topk.indices
+                return encoded_acts_BF, post_topk.values, post_topk.indices, post_relu_feat_acts_BF
             else:
                 return encoded_acts_BF
 
@@ -101,7 +101,7 @@ class AutoEncoderTopK(Dictionary, nn.Module):
         encoded_acts_BF = buffer_BF.scatter_(dim=-1, index=top_indices_BK, src=tops_acts_BK)
 
         if return_topk:
-            return encoded_acts_BF, tops_acts_BK, top_indices_BK
+            return encoded_acts_BF, tops_acts_BK, top_indices_BK, post_relu_feat_acts_BF
         else:
             return encoded_acts_BF
 
@@ -199,8 +199,15 @@ class TopKTrainer(SAETrainer):
             # Auto-select LR using 1 / sqrt(d) scaling law from Figure 3 of the paper
             scale = dict_size / (2**14)
             self.lr = 2e-4 / scale**0.5
+
         self.auxk_alpha = auxk_alpha
         self.dead_feature_threshold = 10_000_000
+        self.top_k_aux = activation_dim // 2  # Heuristic from B.1 of the paper
+        self.num_tokens_since_fired = t.zeros(dict_size, dtype=t.long, device=device)
+        self.logging_parameters = ["effective_l0", "dead_features", "pre_norm_auxk_loss"]
+        self.effective_l0 = -1
+        self.dead_features = -1
+        self.pre_norm_auxk_loss = -1
 
         # Optimizer and scheduler
         self.optimizer = t.optim.Adam(self.ae.parameters(), lr=self.lr, betas=(0.9, 0.999))
@@ -209,90 +216,85 @@ class TopKTrainer(SAETrainer):
 
         self.scheduler = t.optim.lr_scheduler.LambdaLR(self.optimizer, lr_lambda=lr_fn)
 
-        # Training parameters
-        self.num_tokens_since_fired = t.zeros(dict_size, dtype=t.long, device=device)
+    def get_auxiliary_loss(self, residual_BD: t.Tensor, post_relu_acts_BF: t.Tensor):
+        dead_features = self.num_tokens_since_fired >= self.dead_feature_threshold
+        self.dead_features = int(dead_features.sum())
 
-        # Log the effective L0, i.e. number of features actually used, which should a constant value (K)
-        # Note: The standard L0 is essentially a measure of dead features for Top-K SAEs)
-        self.logging_parameters = ["effective_l0", "dead_features"]
-        self.effective_l0 = -1
-        self.dead_features = -1
+        if self.dead_features > 0:
+            k_aux = min(self.top_k_aux, self.dead_features)
 
-    def loss(self, x, step=None, logging=False):
-        # Run the SAE
-        f, top_acts, top_indices = self.ae.encode(x, return_topk=True, use_threshold=False)
-
-        if step > self.threshold_start_step:
-            device_type = 'cuda' if x.is_cuda else 'cpu'
-            with t.autocast(device_type=device_type, enabled=False), t.no_grad():
-                active = top_acts.clone().detach()
-                active[active <= 0] = float("inf")
-                min_activations = active.min(dim=1).values.to(dtype=t.float32)
-                min_activation = min_activations.mean()
-
-                B, K = active.shape
-                assert len(active.shape) == 2
-                assert min_activations.shape == (B,)
-
-                if self.ae.threshold < 0:
-                    self.ae.threshold = min_activation
-                else:
-                    self.ae.threshold = (self.threshold_beta * self.ae.threshold) + (
-                        (1 - self.threshold_beta) * min_activation
-                    )
-
-        x_hat = self.ae.decode(f)
-
-        # Measure goodness of reconstruction
-        e = x_hat - x
-        total_variance = (x - x.mean(0)).pow(2).sum(0)
-
-        # Update the effective L0 (again, should just be K)
-        self.effective_l0 = top_acts.size(1)
-
-        # Update "number of tokens since fired" for each features
-        num_tokens_in_step = x.size(0)
-        did_fire = t.zeros_like(self.num_tokens_since_fired, dtype=t.bool)
-        did_fire[top_indices.flatten()] = True
-        self.num_tokens_since_fired += num_tokens_in_step
-        self.num_tokens_since_fired[did_fire] = 0
-
-        # Compute dead feature mask based on "number of tokens since fired"
-        dead_mask = (
-            self.num_tokens_since_fired > self.dead_feature_threshold
-            if self.auxk_alpha > 0
-            else None
-        ).to(f.device)
-        self.dead_features = int(dead_mask.sum())
-
-        # If dead features: Second decoder pass for AuxK loss
-        if dead_mask is not None and (num_dead := int(dead_mask.sum())) > 0:
-            # Heuristic from Appendix B.1 in the paper
-            k_aux = x.shape[-1] // 2
-
-            # Reduce the scale of the loss if there are a small number of dead latents
-            scale = min(num_dead / k_aux, 1.0)
-            k_aux = min(k_aux, num_dead)
-
-            # Don't include living latents in this loss
-            auxk_latents = t.where(dead_mask[None], f, -t.inf)
+            auxk_latents = t.where(dead_features[None], post_relu_acts_BF, -t.inf)
 
             # Top-k dead latents
             auxk_acts, auxk_indices = auxk_latents.topk(k_aux, sorted=False)
 
-            auxk_buffer_BF = t.zeros_like(f)
+            auxk_buffer_BF = t.zeros_like(post_relu_acts_BF)
             auxk_acts_BF = auxk_buffer_BF.scatter_(dim=-1, index=auxk_indices, src=auxk_acts)
 
-            # Encourage the top ~50% of dead latents to predict the residual of the
-            # top k living latents
-            e_hat = self.ae.decode(auxk_acts_BF)
-            auxk_loss = (e_hat - e).pow(2)  # .sum(0)
-            auxk_loss = scale * t.mean(auxk_loss / total_variance)
+            # Note: decoder(), not decode(), as we don't want to apply the bias
+            x_reconstruct_aux = self.ae.decoder(auxk_acts_BF)
+            l2_loss_aux = (
+                (residual_BD.float() - x_reconstruct_aux.float()).pow(2).sum(dim=-1).mean()
+            )
+
+            self.pre_norm_auxk_loss = l2_loss_aux
+
+            # normalization from OpenAI implementation: https://github.com/openai/sparse_autoencoder/blob/main/sparse_autoencoder/kernels.py#L614
+            residual_mu = residual_BD.mean(dim=0)[None, :].broadcast_to(residual_BD.shape)
+            loss_denom = (residual_BD.float() - residual_mu.float()).pow(2).sum(dim=-1).mean()
+            normalized_auxk_loss = l2_loss_aux / loss_denom
+
+            return normalized_auxk_loss
         else:
-            auxk_loss = x_hat.new_tensor(0.0)
+            self.pre_norm_auxk_loss = -1
+            return t.tensor(0, dtype=residual_BD.dtype, device=residual_BD.device)
+
+    def update_threshold(self, top_acts_BK: t.Tensor):
+        device_type = "cuda" if top_acts_BK.is_cuda else "cpu"
+        with t.autocast(device_type=device_type, enabled=False), t.no_grad():
+            active = top_acts_BK.clone().detach()
+            active[active <= 0] = float("inf")
+            min_activations = active.min(dim=1).values.to(dtype=t.float32)
+            min_activation = min_activations.mean()
+
+            B, K = active.shape
+            assert len(active.shape) == 2
+            assert min_activations.shape == (B,)
+
+            if self.ae.threshold < 0:
+                self.ae.threshold = min_activation
+            else:
+                self.ae.threshold = (self.threshold_beta * self.ae.threshold) + (
+                    (1 - self.threshold_beta) * min_activation
+                )
+
+    def loss(self, x, step=None, logging=False):
+        # Run the SAE
+        f, top_acts_BK, top_indices_BK, post_relu_acts_BF = self.ae.encode(
+            x, return_topk=True, use_threshold=False
+        )
+
+        if step > self.threshold_start_step:
+            self.update_threshold(top_acts_BK)
+
+        x_hat = self.ae.decode(f)
+
+        # Measure goodness of reconstruction
+        e = x - x_hat
+
+        # Update the effective L0 (again, should just be K)
+        self.effective_l0 = top_acts_BK.size(1)
+
+        # Update "number of tokens since fired" for each features
+        num_tokens_in_step = x.size(0)
+        did_fire = t.zeros_like(self.num_tokens_since_fired, dtype=t.bool)
+        did_fire[top_indices_BK.flatten()] = True
+        self.num_tokens_since_fired += num_tokens_in_step
+        self.num_tokens_since_fired[did_fire] = 0
 
         l2_loss = e.pow(2).sum(dim=-1).mean()
-        auxk_loss = auxk_loss.sum(dim=-1).mean()
+        auxk_loss = self.get_auxiliary_loss(e, post_relu_acts_BF) if self.auxk_alpha > 0 else 0
+
         loss = l2_loss + self.auxk_alpha * auxk_loss
 
         if not logging:


### PR DESCRIPTION
A few changes here:

In the first commit, I standardized decoder normalization. In our ConstrainedAdam, we normalized the decoder after the optimizer step, but we did it before the optimizer step for TopK variants and JumpReLU. Now, we always normalize after the optimizer step, ensuring that the final SAE has unit norm decoder vectors.

Secondly, our AuxK loss calculation had some problems. Fixing these leads to a 3x speedup and much less dead features:

- Our AuxK loss was standard MSE loss, while our reconstruction loss summed over the `d_model` dimension: `l2_loss = e.pow(2).sum(dim=-1).mean()`. This effectively scales the reconstruction loss by `d_model` and scales the learning rate (although not by d_model, due to gradient clipping and other factors).
  - In the TopK paper and implementation, they use standard MSE loss. However, I believe we should stick with our existing loss, as that is what all other SAEs are using and we need to use the same reconstruction loss for learning rates to behave equivalently.
  - Because of this, I switched the auxk loss to also summing over the `d_model` dimension, so both the auxk loss and reconstruction loss are on similar scales.
- The BatchTopK and Matroyshka implementations were indexing into acts like so:
```
            acts_topk_aux = t.topk(
                acts[:, dead_features],
                min(self.top_k_aux, dead_features.sum()),
                dim=-1,
            )
            acts_aux = t.zeros_like(acts[:, dead_features]).scatter(
                -1, acts_topk_aux.indices, acts_topk_aux.values
```
-  It turns out that this is pretty slow, and doing this instead sped up training by 3x if there's many dead features:
```
           auxk_latents = t.where(dead_features[None], post_relu_acts_BF, -t.inf)

            # Top-k dead latents
            auxk_acts, auxk_indices = auxk_latents.topk(k_aux, sorted=False)

            auxk_buffer_BF = t.zeros_like(post_relu_acts_BF)
            auxk_acts_BF = auxk_buffer_BF.scatter_(dim=-1, index=auxk_indices, src=auxk_acts)
```
- We should have been using pre-topk acts, not post-topk acts.
- In the OpenAI paper they use an auxk-scale of (1/32). However, they also have a [normalization](https://github.com/openai/sparse_autoencoder/blob/main/sparse_autoencoder/kernels.py#L614) that is mentioned in passing. This normalization changes the typical scale of the auxk loss from [0-0.1] to [1-1.1]. The scale should ideally be applied to values in the expected range. In tests of 500M tokens, using this normalization reduces the number of dead features by up to 30%.