### PR TITLE
Fix broken links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,14 +57,14 @@ This repository supports different sparse autoencoder architectures, including s
 Each sparse autoencoder architecture is implemented with a corresponding trainer that implements the training protocol described by the authors.
 This allows us to implement different training protocols (e.g. p-annealing) for different architectures without a lot of overhead.
 Specifically, this repository supports the following trainers:
-- [`StandardTrainer`](trainers/dictionary_learning/standard.py): Implements a training scheme similar to that of [Bricken et al., 2023](https://transformer-circuits.pub/2023/monosemantic-features/index.html#appendix-autoencoder).
-- [`GatedSAETrainer`](trainers/dictionary_learning/gdm.py): Implements the training scheme for Gated SAEs described in [Rajamanoharan et al., 2024](https://arxiv.org/abs/2404.16014).
-- [`TopKSAETrainer`](trainers/dictionary_learning/top_k.py): Implemented the training scheme for Top-K SAEs described in [Gao et al., 2024](https://arxiv.org/abs/2406.04093).
-- [`BatchTopKSAETrainer`](trainers/dictionary_learning/batch_top_k.py): Implemented the training scheme for Batch Top-K SAEs described in [Bussmann et al., 2024](https://arxiv.org/abs/2412.06410).
-- [`JumpReluTrainer`](trainers/dictionary_learning/jumprelu.py): Implemented the training scheme for JumpReLU SAEs described in [Rajamanoharan et al., 2024](https://arxiv.org/abs/2407.14435).
-- [`PAnnealTrainer`](trainers/dictionary_learning/p_anneal.py): Extends the `StandardTrainer` by providing the option to anneal the sparsity parameter p.
-- [`GatedAnnealTrainer`](trainers/dictionary_learning/gated_anneal.py): Extends the `GatedSAETrainer` by providing the option for p-annealing, similar to `PAnnealTrainer`.
-- [`MatryoshkaBatchTopKTrainer`](trainers/dictionary_learning/matryoshka_batch_top_k.py): Extends the `BatchTopKSAETrainer` by providing the option to apply Matryoshka-style prefix loss training, enabling hierarchical feature learning within a Top-K sparse autoencoder framework.
+- [`StandardTrainer`](dictionary_learning/trainers/standard.py): Implements a training scheme similar to that of [Bricken et al., 2023](https://transformer-circuits.pub/2023/monosemantic-features/index.html#appendix-autoencoder).
+- [`GatedSAETrainer`](dictionary_learning/trainers/gdm.py): Implements the training scheme for Gated SAEs described in [Rajamanoharan et al., 2024](https://arxiv.org/abs/2404.16014).
+- [`TopKSAETrainer`](dictionary_learning/trainers/top_k.py): Implemented the training scheme for Top-K SAEs described in [Gao et al., 2024](https://arxiv.org/abs/2406.04093).
+- [`BatchTopKSAETrainer`](dictionary_learning/trainers/batch_top_k.py): Implemented the training scheme for Batch Top-K SAEs described in [Bussmann et al., 2024](https://arxiv.org/abs/2412.06410).
+- [`JumpReluTrainer`](dictionary_learning/trainers/jumprelu.py): Implemented the training scheme for JumpReLU SAEs described in [Rajamanoharan et al., 2024](https://arxiv.org/abs/2407.14435).
+- [`PAnnealTrainer`](dictionary_learning/trainers/p_anneal.py): Extends the `StandardTrainer` by providing the option to anneal the sparsity parameter p.
+- [`GatedAnnealTrainer`](dictionary_learning/trainers/gated_anneal.py): Extends the `GatedSAETrainer` by providing the option for p-annealing, similar to `PAnnealTrainer`.
+- [`MatryoshkaBatchTopKTrainer`](dictionary_learning/trainers/matryoshka_batch_top_k.py): Extends the `BatchTopKSAETrainer` by providing the option to apply Matryoshka-style prefix loss training, enabling hierarchical feature learning within a Top-K sparse autoencoder framework.
 
 Another key object is the `ActivationBuffer`, defined in `buffer.py`. Following [Neel Nanda's appraoch](https://www.lesswrong.com/posts/fKuugaxt2XLTkASkk/open-source-replication-and-commentary-on-anthropic-s), `ActivationBuffer`s maintain a buffer of NN activations, which it outputs in batches.
 

--- a/README.md
+++ b/README.md
@@ -57,13 +57,14 @@ This repository supports different sparse autoencoder architectures, including s
 Each sparse autoencoder architecture is implemented with a corresponding trainer that implements the training protocol described by the authors.
 This allows us to implement different training protocols (e.g. p-annealing) for different architectures without a lot of overhead.
 Specifically, this repository supports the following trainers:
-- [`StandardTrainer`](trainers/standard.py): Implements a training scheme similar to that of [Bricken et al., 2023](https://transformer-circuits.pub/2023/monosemantic-features/index.html#appendix-autoencoder).
-- [`GatedSAETrainer`](trainers/gdm.py): Implements the training scheme for Gated SAEs described in [Rajamanoharan et al., 2024](https://arxiv.org/abs/2404.16014).
-- [`TopKSAETrainer`](trainers/top_k.py): Implemented the training scheme for Top-K SAEs described in [Gao et al., 2024](https://arxiv.org/abs/2406.04093).
+- [`StandardTrainer`](trainers/dictionary_learning/standard.py): Implements a training scheme similar to that of [Bricken et al., 2023](https://transformer-circuits.pub/2023/monosemantic-features/index.html#appendix-autoencoder).
+- [`GatedSAETrainer`](trainers/dictionary_learning/gdm.py): Implements the training scheme for Gated SAEs described in [Rajamanoharan et al., 2024](https://arxiv.org/abs/2404.16014).
+- [`TopKSAETrainer`](trainers/dictionary_learning/top_k.py): Implemented the training scheme for Top-K SAEs described in [Gao et al., 2024](https://arxiv.org/abs/2406.04093).
 - [`BatchTopKSAETrainer`](trainers/batch_top_k.py): Implemented the training scheme for Batch Top-K SAEs described in [Bussmann et al., 2024](https://arxiv.org/abs/2412.06410).
-- [`JumpReluTrainer`](trainers/jumprelu.py): Implemented the training scheme for JumpReLU SAEs described in [Rajamanoharan et al., 2024](https://arxiv.org/abs/2407.14435).
-- [`PAnnealTrainer`](trainers/p_anneal.py): Extends the `StandardTrainer` by providing the option to anneal the sparsity parameter p.
-- [`GatedAnnealTrainer`](trainers/gated_anneal.py): Extends the `GatedSAETrainer` by providing the option for p-annealing, similar to `PAnnealTrainer`.
+- [`JumpReluTrainer`](trainers/dictionary_learning/jumprelu.py): Implemented the training scheme for JumpReLU SAEs described in [Rajamanoharan et al., 2024](https://arxiv.org/abs/2407.14435).
+- [`PAnnealTrainer`](trainers/dictionary_learning/p_anneal.py): Extends the `StandardTrainer` by providing the option to anneal the sparsity parameter p.
+- [`GatedAnnealTrainer`](trainers/dictionary_learning/gated_anneal.py): Extends the `GatedSAETrainer` by providing the option for p-annealing, similar to `PAnnealTrainer`.
+- [`MatryoshkaBatchTopKTrainer`](trainers/dictionary_learning/matryoshka_batch_top_k.py): Extends the `BatchTopKSAETrainer` by providing the option to apply Matryoshka-style prefix loss training, enabling hierarchical feature learning within a Top-K sparse autoencoder framework.
 
 Another key object is the `ActivationBuffer`, defined in `buffer.py`. Following [Neel Nanda's appraoch](https://www.lesswrong.com/posts/fKuugaxt2XLTkASkk/open-source-replication-and-commentary-on-anthropic-s), `ActivationBuffer`s maintain a buffer of NN activations, which it outputs in batches.
 

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ Specifically, this repository supports the following trainers:
 - [`StandardTrainer`](trainers/dictionary_learning/standard.py): Implements a training scheme similar to that of [Bricken et al., 2023](https://transformer-circuits.pub/2023/monosemantic-features/index.html#appendix-autoencoder).
 - [`GatedSAETrainer`](trainers/dictionary_learning/gdm.py): Implements the training scheme for Gated SAEs described in [Rajamanoharan et al., 2024](https://arxiv.org/abs/2404.16014).
 - [`TopKSAETrainer`](trainers/dictionary_learning/top_k.py): Implemented the training scheme for Top-K SAEs described in [Gao et al., 2024](https://arxiv.org/abs/2406.04093).
-- [`BatchTopKSAETrainer`](trainers/batch_top_k.py): Implemented the training scheme for Batch Top-K SAEs described in [Bussmann et al., 2024](https://arxiv.org/abs/2412.06410).
+- [`BatchTopKSAETrainer`](trainers/dictionary_learning/batch_top_k.py): Implemented the training scheme for Batch Top-K SAEs described in [Bussmann et al., 2024](https://arxiv.org/abs/2412.06410).
 - [`JumpReluTrainer`](trainers/dictionary_learning/jumprelu.py): Implemented the training scheme for JumpReLU SAEs described in [Rajamanoharan et al., 2024](https://arxiv.org/abs/2407.14435).
 - [`PAnnealTrainer`](trainers/dictionary_learning/p_anneal.py): Extends the `StandardTrainer` by providing the option to anneal the sparsity parameter p.
 - [`GatedAnnealTrainer`](trainers/dictionary_learning/gated_anneal.py): Extends the `GatedSAETrainer` by providing the option for p-annealing, similar to `PAnnealTrainer`.


### PR DESCRIPTION
This PR includes the following two updates to the README.md:
1. Fixed broken hyperlinks.
2. Added missing trainer (MatryoshkaBatchTopKTrainer).