### PR TITLE
safer remove_bos logic

### DIFF
--- a/dictionary_learning/buffer.py
+++ b/dictionary_learning/buffer.py
@@ -59,6 +59,11 @@ class ActivationBuffer:
         self.remove_bos = remove_bos
         self.add_special_tokens = add_special_tokens
 
+        print(self.model.tokenizer.padding_side)
+
+        if self.remove_bos:
+            assert self.model.tokenizer.padding_side == "right", "Padding side must be right (bos-trimming logic assumes right padding)"
+
     def __iter__(self):
         return self
 
@@ -138,6 +143,7 @@ class ActivationBuffer:
             if isinstance(hidden_states, tuple):
                 hidden_states = hidden_states[0]
             if self.remove_bos:
+                assert self.model.tokenizer.padding_side == "right", "Padding side must be right (bos-trimming logic assumes right padding)"
                 hidden_states = hidden_states[:, 1:, :]
                 attn_mask = attn_mask[:, 1:]
             hidden_states = hidden_states[attn_mask != 0]

--- a/dictionary_learning/pytorch_buffer.py
+++ b/dictionary_learning/pytorch_buffer.py
@@ -123,6 +123,9 @@ class ActivationBuffer:
 
         if not self.tokenizer.pad_token:
             self.tokenizer.pad_token = self.tokenizer.eos_token
+        
+        if self.remove_bos:
+            assert self.tokenizer.padding_side == "right", "Padding side must be right (bos-trimming logic assumes right padding)"
 
     def __iter__(self):
         return self
@@ -194,6 +197,7 @@ class ActivationBuffer:
                 hidden_states = collect_activations(self.model, self.submodule, input)
             attn_mask = input["attention_mask"]
             if self.remove_bos:
+                assert self.tokenizer.padding_side == "right", "Padding side must be right (bos-trimming logic assumes right padding)"
                 hidden_states = hidden_states[:, 1:, :]
                 attn_mask = attn_mask[:, 1:]
             hidden_states = hidden_states[attn_mask != 0]


### PR DESCRIPTION
The `remove_bos` logic in `ActivationBuffer` assumes right padding (i.e. it assumes that `bos` will always appear as the left-most token):

```
            if self.remove_bos:
                hidden_states = hidden_states[:, 1:, :]
                attn_mask = attn_mask[:, 1:]
```

However, it looks like [by default `nnsight` uses left padding](https://github.com/ndif-team/nnsight/blob/12d436c1accf27386bd79631551a8b6677b57dc1/src/nnsight/modeling/language.py#L119).

This means that unless a user explicitly sets the padding side to right, they will train on `bos` (if using the nnsight-based ActivationBuffer).

I got bit by this unfortunately, and my evaluation metrics (in particular fraction of variance explained) look quite different.

I've added asserts surface this assumption. Could alternatively modify the tokenizer's padding side directly, but I think surfacing the error seems better.