### PR TITLE
Add optional mask for high norm tokens

### DIFF
--- a/dictionary_learning/buffer.py
+++ b/dictionary_learning/buffer.py
@@ -16,7 +16,7 @@ class ActivationBuffer:
     Implements a buffer of activations. The buffer stores activations from a model,
     yields them in batches, and refreshes them when the buffer is less than half full.
 
-    remove_high_norm: remove all activations with norm greater than median norm * remove_high_norm. 10 is a good default.
+    max_activation_norm_multiple: remove all activations with norm greater than median norm * max_activation_norm_multiple. 10 is a good default.
     This is useful for models like Qwen which have random, unpredictable high norm activation sinks which reduce training effectiveness.
     """
     def __init__(self, 
@@ -31,9 +31,9 @@ class ActivationBuffer:
                  out_batch_size=8192, # size of batches in which to yield activations
                  device='cpu', # device on which to store the activations
                  remove_bos: bool = False,
-                add_special_tokens: bool = True,
-                remove_high_norm: int | None = None,
-                 ):
+                 add_special_tokens: bool = True,
+                 max_activation_norm_multiple: int | None = None,
+                ):
         
         if io not in ['in', 'out']:
             raise ValueError("io must be either 'in' or 'out'")
@@ -62,7 +62,7 @@ class ActivationBuffer:
         self.device = device
         self.add_special_tokens = add_special_tokens
         self.remove_bos = remove_bos
-        self.remove_high_norm = remove_high_norm
+        self.remove_high_norm = max_activation_norm_multiple
 
         if remove_bos and self.model.tokenizer.bos_token_id is None:
             print(

--- a/dictionary_learning/pytorch_buffer.py
+++ b/dictionary_learning/pytorch_buffer.py
@@ -74,7 +74,7 @@ class ActivationBuffer:
     Implements a buffer of activations. The buffer stores activations from a model,
     yields them in batches, and refreshes them when the buffer is less than half full.
 
-    remove_high_norm: remove all activations with norm greater than median norm * remove_high_norm. 10 is a good default.
+    max_activation_norm_multiple: remove all activations with norm greater than median norm * max_activation_norm_multiple. 10 is a good default.
     This is useful for models like Qwen which have random, unpredictable high norm activation sinks which reduce training effectiveness.
     """
 
@@ -92,7 +92,7 @@ class ActivationBuffer:
         device="cpu",  # device on which to store the activations
         remove_bos: bool = False,
         add_special_tokens: bool = True,
-        remove_high_norm: int | None = None,
+        max_activation_norm_multiple: int | None = None,
     ):
         if io not in ["in", "out"]:
             raise ValueError("io must be either 'in' or 'out'")
@@ -124,7 +124,7 @@ class ActivationBuffer:
         self.add_special_tokens = add_special_tokens
         self.tokenizer = AutoTokenizer.from_pretrained(model.name_or_path)
         self.remove_bos = remove_bos
-        self.remove_high_norm = remove_high_norm
+        self.remove_high_norm = max_activation_norm_multiple
 
         if remove_bos and self.tokenizer.bos_token_id is None:
             print(

--- a/dictionary_learning/pytorch_buffer.py
+++ b/dictionary_learning/pytorch_buffer.py
@@ -73,6 +73,9 @@ class ActivationBuffer:
     """
     Implements a buffer of activations. The buffer stores activations from a model,
     yields them in batches, and refreshes them when the buffer is less than half full.
+
+    remove_high_norm: remove all activations with norm greater than median norm * remove_high_norm. 10 is a good default.
+    This is useful for models like Qwen which have random, unpredictable high norm activation sinks which reduce training effectiveness.
     """
 
     def __init__(
@@ -89,6 +92,7 @@ class ActivationBuffer:
         device="cpu",  # device on which to store the activations
         remove_bos: bool = False,
         add_special_tokens: bool = True,
+        remove_high_norm: int | None = None,
     ):
         if io not in ["in", "out"]:
             raise ValueError("io must be either 'in' or 'out'")
@@ -120,6 +124,7 @@ class ActivationBuffer:
         self.add_special_tokens = add_special_tokens
         self.tokenizer = AutoTokenizer.from_pretrained(model.name_or_path)
         self.remove_bos = remove_bos
+        self.remove_high_norm = remove_high_norm
 
         if remove_bos and self.tokenizer.bos_token_id is None:
             print(
@@ -207,6 +212,13 @@ class ActivationBuffer:
                     assert mask.dim() == 2, "expected shape (batch_size, seq_len)"
                     first_one = (mask.to(t.int64).cumsum(dim=1) == 1) & mask
                     mask = mask & ~first_one
+
+            if self.remove_high_norm is not None:
+                # some models (like Qwen) have random high norm activation sinks which reduce training effectiveness
+                norms_BL = hidden_states.norm(dim=-1)
+                median_norm = norms_BL.median()
+                norm_mask = norms_BL > median_norm * self.remove_high_norm
+                mask = mask & ~norm_mask
 
             hidden_states = hidden_states[mask]
 


### PR DESCRIPTION
When training SAEs on Qwen models, I found that as we move to later layers and larger models (e.g. Qwen3-32B), the activations begin to have random attention sinks with extremely high activation norms (> 100x the median). They appear randomly in the sequence, often on seemingly unimportant tokens like the (0) in my_list.append(0).

This reduces the frac variance explained by around 3% and adds loss spikes. It also adds a significant amount of dead features early in training (often 25% or more), although this does seem to go away after 100M tokens or so.

To remove this, I added an optional argument, which if present, we filter out activations with a norm greater than `max_activation_norm_multiple` * median activation norm.

As an example, we can see the orange and green lines both have multiple high activation norms in a single sequence. 

<img width="470" height="374" alt="Screenshot 2025-08-20 at 11 40 34 AM" src="https://github.com/user-attachments/assets/31bef00f-9aa5-47a4-a0ee-a4f22bd5a5da" />
